### PR TITLE
dont init git when inside existing repo

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -117,10 +117,12 @@ pub(crate) fn remove_history(project_dir: &Path) -> Result<()> {
 }
 
 pub fn init(project_dir: &Path, branch: &str) -> Result<GitRepository> {
-    let mut opts = RepositoryInitOptions::new();
-    opts.bare(false);
-    opts.initial_head(branch);
-    GitRepository::init_opts(project_dir, &opts).context("Couldn't init new repository")
+    GitRepository::discover(project_dir).or_else(|_| {
+        let mut opts = RepositoryInitOptions::new();
+        opts.bare(false);
+        opts.initial_head(branch);
+        GitRepository::init_opts(project_dir, &opts).context("Couldn't init new repository")
+    })
 }
 
 #[cfg(test)]

--- a/tests/integration/helpers/project.rs
+++ b/tests/integration/helpers/project.rs
@@ -1,36 +1,32 @@
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::str;
+
+use tempfile::TempDir;
 
 #[derive(Debug)]
 pub struct Project {
-    pub root: PathBuf,
+    pub(crate) root: TempDir,
 }
 
 impl Project {
     pub fn read(&self, path: &str) -> String {
         let mut ret = String::new();
-        File::open(self.root.join(path))
-            .unwrap_or_else(|_| panic!("couldn't open file {:?}", self.root.join(path)))
+        let path = self.path().join(path);
+        File::open(&path)
+            .unwrap_or_else(|_| panic!("couldn't open file {:?}", path))
             .read_to_string(&mut ret)
-            .unwrap_or_else(|_| panic!("couldn't read file {:?}", self.root.join(path)));
+            .unwrap_or_else(|_| panic!("couldn't read file {:?}", path));
 
         ret
     }
 
     pub fn path(&self) -> &Path {
-        &self.root
+        self.root.path()
     }
 
     pub fn exists(&self, path: &str) -> bool {
-        self.root.join(path).exists()
-    }
-}
-
-impl Drop for Project {
-    fn drop(&mut self) {
-        drop(fs::remove_dir_all(&self.root));
-        drop(fs::remove_dir(&self.root));
+        self.path().join(path).exists()
     }
 }

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -1,9 +1,9 @@
-use crate::helpers::project_builder::dir;
+use crate::helpers::project_builder::tmp_dir;
 use cargo_generate::{generate, Args};
 
 #[test]
 fn it_allows_generate_call_with_public_args() {
-    let template = dir("template")
+    let template = tmp_dir()
         .file(
             "Cargo.toml",
             r#"[package]
@@ -15,7 +15,7 @@ version = "0.1.0"
         .init_git()
         .build();
 
-    let dir = dir("main").build();
+    let dir = tmp_dir().build();
 
     let args_exposed: Args = Args {
         git: format!("{}", template.path().display()),


### PR DESCRIPTION
When generating templates inside an existing repository, there is no need to attempt the initialization of a new one - in fact it just makes it harder to integrate the new template!
