### PR TITLE
Add --vcs option to avoid initializing git repo

### DIFF
--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -1,5 +1,5 @@
 use crate::helpers::project_builder::tmp_dir;
-use cargo_generate::{generate, Args};
+use cargo_generate::{generate, Args, Vcs};
 
 #[test]
 fn it_allows_generate_call_with_public_args() {
@@ -22,6 +22,7 @@ version = "0.1.0"
         branch: Some(String::from("main")),
         name: Some(String::from("foobar_project")),
         force: true,
+        vcs: Vcs::Git,
         verbose: true,
         template_values_file: None,
         silent: false,


### PR DESCRIPTION
#244 asks for an option to specify NOT to initialize the git repository.
This implements such an option, with possibility to be expanded into
other VCS systems.