### PR TITLE
Add feature to use folders as templates (or sub-folders in git).

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ cargo install cargo-generate --features vendored-openssl
 
 ## Usage
 
+### Template in a git repository
+
 Standard usage is to pass a `--git` flag to `cargo generate` or short `cargo gen`. This will prompt you to enter the name of your project.
 
 ```sh
@@ -52,9 +54,25 @@ You can also pass the name of your project to the tool using the `--name` or `-n
 cargo generate --git https://github.com/githubusername/mytemplate.git --name myproject
 ```
 
-## Favorites
+### Template in a local directory, or git sub-directory
 
-Favorite templates can be defined in a config file, that by default is placed at `$CARGO_HOME/cargo-generate`. 
+Besides `--git` to specify the template repository, `cargo-generate` supports a `--dir` option to specify a local directory as the template.
+
+```sh
+cargo generate --dir ~/my-template-directory --name myproject
+```
+
+Using `--dir` and `--git` together, allows `cargo-generate` to use a sub-directory inside the git repository as the template.
+
+This enables a git repository to contain multiple templates.
+
+```sh
+cargo generate --git username/multi-template-repo --dir directory-in-repo
+```
+
+### Favorites
+
+Favorite templates can be defined in a config file, that by default is placed at `$CARGO_HOME/cargo-generate`.
 To specify an alternative configuration file, use the `--config <config-file>` option.
 
 Each favorite template is specified in its own section, e.g.:
@@ -64,9 +82,12 @@ Each favorite template is specified in its own section, e.g.:
 description = "Demo template for cargo-generate"
 git = "https://github.com/ashleygwilliams/wasm-pack-template"
 branch = "master"
+dir = "directory-for-the-template"
 ```
 
-Both `branch` and `description` are optional, and the branch may be overridden by specifying `--branch <branch>` on the command line.
+`branch`, `description` and `dir` are all optional.
+
+`branch` and `dir` may both be overridden by specifying the corresponding options on the command line.
 
 When favorites are available, they can be generated simply by invoking:
 
@@ -90,7 +111,7 @@ supported placeholders are:
 - `{{crate_name}}`: the snake_case_version of `project-name`
 - `{{os-arch}}`: contains the current operating system and architecture ex: `linux-x86_64`
 
-Additionally all filters and tags of the liquid template language are supported. 
+Additionally all filters and tags of the liquid template language are supported.
 For more information, check out the [Liquid Documentation on `Tags` and `Filters`][liquid].
 
 [liquid]: https://shopify.github.io/liquid
@@ -106,11 +127,11 @@ If you have a great template that you'd like to feature here, please [file an is
 
 ## Template defined placeholders
 
-Sometimes templates need to make decisions. For example one might want to conditionally include some code or not. 
+Sometimes templates need to make decisions. For example one might want to conditionally include some code or not.
 Another use case might be that the user of a template should be able to choose out of provided options in an interactive way.
 Also it might be helpful to offer a reasonable default value that the user just simply can use.
 
-Since version [0.6.0](https://github.com/cargo-generate/cargo-generate/releases/tag/v0.6.0) it is possible to use placeholders in a `cargo-generate.toml` that is in the root folder of a template.  
+Since version [0.6.0](https://github.com/cargo-generate/cargo-generate/releases/tag/v0.6.0) it is possible to use placeholders in a `cargo-generate.toml` that is in the root folder of a template.
 Here [an example](https://github.com/sassman/hermit-template-rs):
 
 ```toml
@@ -150,6 +171,7 @@ fn main() {
 ```
 
 > Note: similar to `dependencies` in the `Cargo.toml` file you can also list them as one liners:
+
 ```toml
 [placeholders]
 hypervisor = { type = "string", prompt = "What hypervisor to use?", choices = ["uhyve", "qemu"], default = "qemu" }
@@ -170,7 +192,7 @@ A placeholder can be of type `string` or `bool`. Boolean types are usually helpf
 
 ### `choices` property (optional)
 
-A placeholder can come with a list of choices that the user can choose from. 
+A placeholder can come with a list of choices that the user can choose from.
 It's further also validated at the time when a user generates a project from a template.
 
 ```toml
@@ -188,12 +210,13 @@ default = 'qemu'
 
 ### `regex` property (optional)
 
-A `regex` property is a string, that can be used to enforce a certain validation rule. The input dialog will keep repeating 
+A `regex` property is a string, that can be used to enforce a certain validation rule. The input dialog will keep repeating
 until the user entered something that is allowed by this regex.
 
 ### Placeholder Examples
 
 An example with a regex that allows only numbers
+
 ```toml
 [placeholders]
 phone_number = { type = "string", prompt = "What's your phone number?", regex = "[0-9]+" }
@@ -214,8 +237,8 @@ network_enabled = true
 ## Include / Exclude
 
 Templates support a `cargo-generate.toml`, with a "template" section that allows you to configure the files that will be processed by `cargo-generate`.
-The behavior mirrors Cargo's Include / Exclude functionality, which is [documented here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields-optional). 
-If you are using placeholders in a file name, and also wish to use placeholders in the contents of that file, 
+The behavior mirrors Cargo's Include / Exclude functionality, which is [documented here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields-optional).
+If you are using placeholders in a file name, and also wish to use placeholders in the contents of that file,
 you should setup your globs to match on the pre-rename filename.
 
 ```toml

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -17,6 +17,7 @@ pub(crate) struct AppConfig {
 pub(crate) struct FavoriteConfig {
     pub description: Option<String>,
     pub git: Option<String>,
+    pub dir: Option<PathBuf>,
     pub branch: Option<String>,
 }
 

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -2,7 +2,7 @@ use crate::{
     app_config::{app_config_path, AppConfig, FavoriteConfig},
     Args,
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 
 pub(crate) fn list_favorites(args: &Args) -> Result<()> {
     let path = &app_config_path(&args.config)?;
@@ -35,14 +35,14 @@ pub(crate) fn list_favorites(args: &Args) -> Result<()> {
 }
 
 pub(crate) fn resolve_favorite(args: &mut Args) -> Result<()> {
-    if args.git.is_some() {
+    if args.git.is_some() || args.dir.is_some() {
         return Ok(());
     }
 
     let favorite_name = args
         .favorite
         .as_ref()
-        .ok_or_else(|| anyhow!("Please specify either --git option, or a predefined favorite"))?;
+        .context("Please specify either --git, --dir, or a predefined favorite")?;
 
     let app_config_path = app_config_path(&args.config)?;
     let app_config = AppConfig::from_path(app_config_path.as_path())?;
@@ -58,6 +58,7 @@ pub(crate) fn resolve_favorite(args: &mut Args) -> Result<()> {
         })?;
 
     args.git = favorite.git.clone();
+    args.dir = args.dir.as_ref().or_else(|| favorite.dir.as_ref()).cloned();
     args.branch = args
         .branch
         .as_ref()

--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -1,0 +1,17 @@
+use std::{fs, io, path::Path};
+
+pub(crate) fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    fs::create_dir_all(&dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            if entry.file_name() != ".git" {
+                copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+            }
+        } else {
+            fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}

--- a/src/git.rs
+++ b/src/git.rs
@@ -65,7 +65,7 @@ impl GitConfig {
     }
 }
 
-pub(crate) fn create(project_dir: &Path, args: GitConfig) -> Result<String> {
+pub(crate) fn create(project_dir: &Path, args: &GitConfig) -> Result<String> {
     let temp = Builder::new().prefix(project_dir).tempdir()?;
     let config = Config::default()?;
     let remote = GitRemote::new(&args.remote);

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -1092,3 +1092,73 @@ version = "0.1.0"
         .contains("foobar-project"));
     assert!(Repository::open(dir.path().join("foobar-project")).is_err());
 }
+
+#[test]
+fn it_can_generate_from_a_directory() {
+    // Build and commit on branch named 'main'
+    let template = tmp_dir()
+        .file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .build();
+    let dir = tmp_dir().build();
+
+    binary()
+        .arg("generate")
+        .arg("--dir")
+        .arg(template.path())
+        .arg("--name")
+        .arg("foobar-project")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(dir
+        .read("foobar-project/Cargo.toml")
+        .contains("foobar-project"));
+}
+
+#[test]
+fn it_can_generate_from_a_git_subdir() {
+    // Build and commit on branch named 'main'
+    let template = tmp_dir()
+        .file(
+            "README",
+            r#"# README
+Test repository with sub-dir containing the template"#,
+        )
+        .file(
+            "sub-dir/Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .init_git()
+        .build();
+    let dir = tmp_dir().build();
+
+    binary()
+        .arg("generate")
+        .arg("--git")
+        .arg(template.path())
+        .arg("--dir")
+        .arg("sub-dir")
+        .arg("--name")
+        .arg("foobar-project")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(dir
+        .read("foobar-project/Cargo.toml")
+        .contains("foobar-project"));
+}

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -1125,7 +1125,7 @@ version = "0.1.0"
 }
 
 #[test]
-fn it_can_generate_from_a_git_subdir() {
+fn it_can_pick_from_the_template() {
     // Build and commit on branch named 'main'
     let template = tmp_dir()
         .file(
@@ -1149,7 +1149,7 @@ version = "0.1.0"
         .arg("generate")
         .arg("--git")
         .arg(template.path())
-        .arg("--dir")
+        .arg("--pick")
         .arg("sub-dir")
         .arg("--name")
         .arg("foobar-project")

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -30,6 +30,7 @@ version = "0.1.0"
         list_favorites: false,
         config: None,
         favorite: None,
+        pick: vec![],
     };
     // need to cd to the dir as we aren't running in the cargo shell.
     assert!(std::env::set_current_dir(&dir.root).is_ok());

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -19,6 +19,7 @@ version = "0.1.0"
 
     let args_exposed: Args = Args {
         git: Some(format!("{}", template.path().display())),
+        dir: None,
         branch: Some(String::from("main")),
         name: Some(String::from("foobar_project")),
         force: true,


### PR DESCRIPTION
**July 26, 2021 - UPDATE**
Redesigned the feature to only allow selection into git-repositories, thereby avoiding most if not all the problems mentioned in this PR (see #379) .


Using folders alone allows to use templates that are not in git,
but together with git, it allows to specify a sub-folder within
the repository, that contains the actual template.

This allows us to have multiple templates in a single repository.

Relates to #78 (Project examples as templates)