### PR TITLE
feat(variables): enter leads to default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ fn progress(
         None => Ok(template),
         Some(config) => {
             project_variables::fill_project_varibles(template, config, args.silent, |slot| {
-                interactive::variable(slot, interactive::user_question)
+                interactive::variable(slot)
             })
         }
     }?;

--- a/src/project_variables.rs
+++ b/src/project_variables.rs
@@ -17,7 +17,7 @@ pub(crate) struct TemplateSlots {
 #[derive(Debug, Clone)]
 pub(crate) enum VarInfo {
     Bool { default: Option<bool> },
-    String { entry: Box<StringEntry> },
+    String { entry: StringEntry },
 }
 
 #[derive(Debug, Clone)]
@@ -159,19 +159,19 @@ fn try_key_value_into_slot(
             default: Some(value),
         },
         (SupportedVarType::String, Some(SupportedVarValue::String(value))) => VarInfo::String {
-            entry: Box::new(StringEntry {
+            entry: StringEntry {
                 default: Some(value),
                 choices,
                 regex,
-            }),
+            },
         },
         (SupportedVarType::Bool, None) => VarInfo::Bool { default: None },
         (SupportedVarType::String, None) => VarInfo::String {
-            entry: Box::new(StringEntry {
+            entry: StringEntry {
                 default: None,
                 choices,
                 regex,
-            }),
+            },
         },
         _ => unreachable!("It should not have come to this..."),
     };

--- a/src/project_variables.rs
+++ b/src/project_variables.rs
@@ -17,7 +17,7 @@ pub(crate) struct TemplateSlots {
 #[derive(Debug, Clone)]
 pub(crate) enum VarInfo {
     Bool { default: Option<bool> },
-    String { entry: StringEntry },
+    String { entry: Box<StringEntry> },
 }
 
 #[derive(Debug, Clone)]
@@ -159,19 +159,19 @@ fn try_key_value_into_slot(
             default: Some(value),
         },
         (SupportedVarType::String, Some(SupportedVarValue::String(value))) => VarInfo::String {
-            entry: StringEntry {
+            entry: Box::new(StringEntry {
                 default: Some(value),
                 choices,
                 regex,
-            },
+            }),
         },
         (SupportedVarType::Bool, None) => VarInfo::Bool { default: None },
         (SupportedVarType::String, None) => VarInfo::String {
-            entry: StringEntry {
+            entry: Box::new(StringEntry {
                 default: None,
                 choices,
                 regex,
-            },
+            }),
         },
         _ => unreachable!("It should not have come to this..."),
     };


### PR DESCRIPTION
This PR does this:
 - when the user is prompted to enter a value, enter key did not lead to use the default
   now the in brackets presented default will be used, once the user hits enter
 - also: refactor the interactive project / crate variable collection to reuse the
    based interactive way, in order to eat your own dogfood