### PR TITLE
feat(favorites:fallback): backwards compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,12 +243,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -373,7 +367,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -382,7 +376,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -392,7 +386,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -403,7 +397,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "const_fn",
  "crossbeam-utils",
  "lazy_static",
@@ -418,7 +412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -535,7 +529,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall 0.1.57",
  "winapi",
@@ -547,7 +541,7 @@ version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
  "libz-sys",
@@ -619,7 +613,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4060f4657be78b8e766215b02b18a2e862d83745545de804638e2b545e81aee6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -931,11 +925,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1054,7 +1048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -1534,7 +1528,7 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "winapi",
 ]
@@ -1606,7 +1600,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "rand",
  "redox_syscall 0.2.4",

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ or slightly more involved:
 cargo generate demo --branch master --name expanded_demo
 ```
 
+> NOTE: when `<favorite>` is not defined in the config file, it is interpreted as a git repo like as if `--git <favorite>`
+
 ## Templates
 
 Templates are git repositories whose files contain placeholders. The current

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -13,7 +13,7 @@ pub(crate) struct AppConfig {
     pub favorites: HashMap<String, FavoriteConfig>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 pub(crate) struct FavoriteConfig {
     pub description: Option<String>,
     pub git: Option<String>,

--- a/src/emoji.rs
+++ b/src/emoji.rs
@@ -4,4 +4,4 @@ pub(crate) static ERROR: Emoji<'_, '_> = Emoji("⛔  ", "");
 pub(crate) static SPARKLE: Emoji<'_, '_> = Emoji("✨  ", "");
 pub(crate) static WARN: Emoji<'_, '_> = Emoji("⚠️  ", "");
 pub(crate) static WRENCH: Emoji<'_, '_> = Emoji("🔧  ", "");
-pub(crate) static SHRUG: Emoji<'_, '_> = Emoji("🤷 ", "");
+pub(crate) static SHRUG: Emoji<'_, '_> = Emoji("🤷  ", "");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ mod git;
 mod ignoreme;
 mod include_exclude;
 mod interactive;
+mod log;
 mod progressbar;
 mod project_variables;
 mod projectname;
@@ -344,9 +345,8 @@ fn gen_success(dir: &Path) {
 
 fn rename_warning(name: &ProjectName) {
     if !name.is_crate_name() {
-        println!(
-            "{} {} `{}` {} `{}`{}",
-            emoji::WARN,
+        info!(
+            "{} `{}` {} `{}`{}",
             style("Renaming project called").bold(),
             style(&name.user_input).bold().yellow(),
             style("to").bold(),

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,9 @@
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => ({
+        println!("{} {}",
+            $crate::emoji::WARN,
+            format!($($arg)*)
+        );
+    })
+}

--- a/tests/integration/favorites.rs
+++ b/tests/integration/favorites.rs
@@ -126,7 +126,7 @@ fn git_specification_overrides_favorite() {
 }
 
 #[test]
-fn favorites_fail_if_not_defined() {
+fn favorites_default_to_git_if_not_defined() {
     let favorite_template = create_template("favorite-template");
     let (_config, config_path) = create_favorite_config("test", &favorite_template);
     let dir = tmp_dir().build();
@@ -141,5 +141,10 @@ fn favorites_fail_if_not_defined() {
         .current_dir(&dir.path())
         .assert()
         .failure()
-        .stderr(predicates::str::contains(r#"Unknown favorite: dummy"#).from_utf8());
+        .stderr(
+            predicates::str::contains(
+                r#"Git Error: unexpected http status code: 404; class=Http (34)"#,
+            )
+            .from_utf8(),
+        );
 }

--- a/tests/integration/favorites.rs
+++ b/tests/integration/favorites.rs
@@ -141,10 +141,5 @@ fn favorites_default_to_git_if_not_defined() {
         .current_dir(&dir.path())
         .assert()
         .failure()
-        .stderr(
-            predicates::str::contains(
-                r#"Git Error: unexpected http status code: 404; class=Http (34)"#,
-            )
-            .from_utf8(),
-        );
+        .stderr(predicates::str::contains(r#"status code: 404"#).from_utf8());
 }


### PR DESCRIPTION
this PR ensures backwards compatibility to v0.5.x so that the favorite feature does not create any harm for long term users. So in detail that looks like this:

 - when a user provides an argument such as `sassman/hermit-template-rs` without `--git`
 - then this is looked up in the favourites but in case it is missing
   we log a warning and use it as a git repo as if the user provided `--git sassman/hermit-template-rs`
 - so we remain backwards compatible
 - a user will likely notices about the favorites feature (warning message)
 - insteaf of failing handle what the user want more gracefully, more peace of mind