### PR TITLE
Feature: specify subdir in repo as template

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ You can also pass the name of your project to the tool using the `--name` or `-n
 cargo generate --git https://github.com/githubusername/mytemplate.git --name myproject
 ```
 
+If the git repository contains multiple templates, the specific subfolder in the git repository may be specified like this:
+
+```sh
+cargo generate --git "https://github.com/githubusername/mytemplate.git <relative-template-path>"
+```
+
+> NOTE: The specified `relative-template-path` will be used as the actual template root, whether or not this is actually true!
+
+> NOTE: When using the `subfolder` feature, `cargo-generate` will search for
+
 ## git over ssh
 
 New in version [0.7.0] is the support for both public and private and ssh git remote urls.
@@ -82,7 +92,7 @@ cargo generate --git rustwasm/wasm-pack-template --name mywasm
 
 ## http(s) proxy
 
-New in version [0.7.0] is automatic proxy usage. So, if http(s)_PROXY env variables are provided, they 
+New in version [0.7.0] is automatic proxy usage. So, if http(s)\_PROXY env variables are provided, they 
 will be used for cloning a http(s) template repository. 
 
 ## Favorites
@@ -94,12 +104,13 @@ Each favorite template is specified in its own section, e.g.:
 
 ```toml
 [favorites.demo]
-description = "Demo template for cargo-generate"
+description = "<optional description, visible with --list-favorites>"
 git = "https://github.com/ashleygwilliams/wasm-pack-template"
-branch = "master"
+branch = "<optional-branch>"
+subfolder = "<optional-subfolder>"
 ```
 
-Both `branch` and `description` are optional, and the branch may be overridden by specifying `--branch <branch>` on the command line.
+Values may be overridden using the CLI arguments of the same names (e.g. `--subfolder` for the `subfolder` value).
 
 When favorites are available, they can be generated simply by invoking:
 
@@ -110,7 +121,7 @@ cargo gen <favorite>
 or slightly more involved:
 
 ```cli
-cargo generate demo --branch master --name expanded_demo
+cargo generate demo --branch mybranch --name expanded_demo --subfolder myfolder
 ```
 
 > NOTE: when `<favorite>` is not defined in the config file, it is interpreted as a git repo like as if `--git <favorite>`
@@ -294,6 +305,8 @@ include = ["Cargo.toml"]
 # include and exclude are exclusive, if both appear we will use include
 exclude = ["*.c"]
 ```
+
+The `cargo-generate.toml` file should be placed in the root of the template. If using the `subfolder` feature, the root is the `subfolder` inside the repository, though `cargo-generate` will look for the file in all parent folders until it reaches the repository root.
 
 ## Cargo gen - alias
 

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -18,6 +18,7 @@ pub(crate) struct FavoriteConfig {
     pub description: Option<String>,
     pub git: Option<String>,
     pub branch: Option<String>,
+    pub subfolder: Option<String>,
 }
 
 impl Default for AppConfig {

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -35,7 +35,7 @@ pub(crate) fn list_favorites(args: &Args) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn resolve_favorite(args: &mut Args) -> Result<()> {
+pub(crate) fn resolve_favorite_args(args: &mut Args) -> Result<()> {
     if args.git.is_some() {
         return Ok(());
     }
@@ -47,7 +47,8 @@ pub(crate) fn resolve_favorite(args: &mut Args) -> Result<()> {
 
     let app_config_path = app_config_path(&args.config)?;
     let app_config = AppConfig::from_path(app_config_path.as_path())?;
-    let favorite = app_config
+
+    let (git, branch) = app_config
         .favorites
         .get(favorite_name.as_str())
         .map_or_else(
@@ -65,8 +66,8 @@ pub(crate) fn resolve_favorite(args: &mut Args) -> Result<()> {
                 )
             },
         );
-    args.git = favorite.0;
-    args.branch = favorite.1;
+    args.git = git;
+    args.branch = branch;
 
     Ok(())
 }

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -20,6 +20,7 @@ version = "0.1.0"
     let args_exposed: Args = Args {
         git: Some(format!("{}", template.path().display())),
         branch: Some(String::from("main")),
+        subfolder: None,
         name: Some(String::from("foobar_project")),
         force: true,
         vcs: Vcs::Git,


### PR DESCRIPTION
This change allows to specify a sub-folder inside a git repository for use as the template.

By doing so, it allows us to e.g. generate projects from examples inside a repo, or to have a repo that contains multiple templates.

Relates to #47 and #78 

This pull-request will also make #295 obsolete, as there is no need to specify folders as templates, and thus we avoid a lot of the problems specified in #295 and #291, allowing for easier implementation of #291 (and thus #211).

@sassman Sorry for the long timeout here - as it seems we get no feedback for #295, I suggest this one instead. I still like the idea of `--pick` for #291, but it kinda conflicted and this is my proposal to remedy that!