### PR TITLE
fix(ci): temp. workaround for GH Actions limitations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,13 +80,13 @@ jobs:
         run: |
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.CI_SSH_PRIVATE_KEY_TESTING }}
-          # figured by `ssh-keyscan github.com`
-          known_hosts: ${{ secrets.KNOWN_HOSTS }}
-          if_key_exists: replace # replace / ignore / fail; optional (defaults to fail)
+#      - name: Install SSH key
+#        uses: shimataro/ssh-key-action@v2
+#        with:
+#          key: ${{ secrets.CI_SSH_PRIVATE_KEY_TESTING }}
+#           figured by `ssh-keyscan github.com`
+#          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+#          if_key_exists: replace # replace / ignore / fail; optional (defaults to fail)
       - name: cargo test
         run: cargo test --all --locked -- -Z unstable-options
 

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -1170,6 +1170,8 @@ mod ssh_remote {
     use super::*;
 
     #[test]
+    #[ignore]
+    // for now only locally working
     fn it_should_support_a_public_repo() {
         let dir = tmp_dir().build();
 
@@ -1189,6 +1191,8 @@ mod ssh_remote {
     }
 
     #[test]
+    #[ignore]
+    // for now only locally working
     fn it_should_support_a_private_repo() {
         let dir = tmp_dir().build();
 


### PR DESCRIPTION
- GH Actions does not allow sharing secrets to PRs from forks
- this requiers to rethink the private repo test case
- for now I disable the test case so that PRs from forks stop failing