### PR TITLE
Improve output of --list-favorites.

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -1,10 +1,13 @@
 use anyhow::{Context, Result};
+use console::style;
 use serde::Deserialize;
 use std::{
     collections::HashMap,
     fs,
     path::{Path, PathBuf},
 };
+
+use crate::emoji;
 
 pub(crate) const CONFIG_FILE_NAME: &str = "cargo-generate";
 
@@ -36,6 +39,12 @@ impl AppConfig {
             Ok(if cfg.trim().is_empty() {
                 AppConfig::default()
             } else {
+                println!(
+                    "{} {} {}",
+                    emoji::INFO,
+                    style("Using application config:").bold(),
+                    style(path.display()).underlined()
+                );
                 toml::from_str(&cfg)?
             })
         } else {

--- a/src/emoji.rs
+++ b/src/emoji.rs
@@ -6,3 +6,4 @@ pub(crate) static WARN: Emoji<'_, '_> = Emoji("⚠️  ", "");
 pub(crate) static WRENCH: Emoji<'_, '_> = Emoji("🔧  ", "");
 pub(crate) static SHRUG: Emoji<'_, '_> = Emoji("🤷  ", "");
 pub(crate) static INFO: Emoji<'_, '_> = Emoji("💡  ", "");
+pub(crate) static DIAMOND: Emoji<'_, '_> = Emoji("🔸  ", "");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,11 @@ use std::{
 use structopt::StructOpt;
 use tempfile::TempDir;
 
-use crate::git::GitConfig;
 use crate::template_variables::{CrateType, ProjectName};
+use crate::{
+    app_config::{app_config_path, AppConfig},
+    git::GitConfig,
+};
 
 #[derive(StructOpt)]
 #[structopt(bin_name = "cargo")]
@@ -211,11 +214,14 @@ impl FromStr for Vcs {
 }
 
 pub fn generate(mut args: Args) -> Result<()> {
+    let path = &app_config_path(&args.config)?;
+    let app_config = AppConfig::from_path(path)?;
+
     if args.list_favorites {
-        return list_favorites(&args);
+        return list_favorites(&app_config, &args);
     }
 
-    resolve_favorite_args(&mut args)?;
+    resolve_favorite_args(&app_config, &mut args)?;
 
     let project_name = resolve_project_name(&args)?;
     let project_dir = create_project_dir(&project_name, args.force)?;


### PR DESCRIPTION
Improves the output of `--list-favorites` to be more in line with the normal output.

Also moves where the `AppConfig` is read. As it is more of a global config file than solely for favorites.