### PR TITLE
template: Process Directories and Files

### DIFF
--- a/tests/integration/filenames.rs
+++ b/tests/integration/filenames.rs
@@ -12,6 +12,10 @@ fn it_substitutes_filename() {
             "{{project-name}}.rs",
             r#"println!("Welcome in {{project-name}}");"#,
         )
+        .file(
+            "src/{{project-name}}/lib.rs",
+            r#"println!("Welcome in {{project-name}}-lib");"#,
+        )
         .init_git()
         .build();
 
@@ -35,5 +39,13 @@ fn it_substitutes_filename() {
     assert!(
         dir.exists("foobar-project/foobar-project.rs"),
         "project should contain foobar-project/foobar-project.rs"
+    );
+    assert!(
+        dir.exists("foobar-project/src/foobar-project/lib.rs"),
+        "project should contain foobar-project/src/foobar-project/lib.rs"
+    );
+    assert!(
+        !dir.exists("foobar-project/src/{{project-name}}/lib.rs"),
+        "project should not contain foobar-project/src/foobar-project/lib.rs"
     );
 }


### PR DESCRIPTION
In order to properly allow for templates in directory names, we must
adjust the WalkDir to include both files and directories AND to yield
contents first.

Given that the project name is bar, and the directory tree:

| {{project-name}}/foo.rs
| {{projcet-name}}

- {{project-name}}/foo.rs is read and the contents rendered
- fs:create_dir_all will create the bar directory
- fs::write will write bar/foo.rs
- the {{project-name}} directory is then deleted with fs::remove_dir_all

Which will provide:

| bar/foo.rs

Fixes: #396

Command output from this commit:
```
🔧   Creating project called `foo`...
[ 1/12]   Done: .appveyor.yml
[ 2/12]   Done: .gitignore
[ 3/12]   Done: .travis.yml
[ 4/12]   Done: Cargo.toml
[ 5/12]   Done: LICENSE_APACHE
[ 6/12]   Done: LICENSE_MIT
[ 7/12]   Done: README.md
[ 8/12]   Done: src/lib.rs
[ 9/12]   Done: src/utils.rs
[10/12]   Done: src
[11/12]   Done: tests/web.rs
[12/12]   Done: tests
✨   Done! New project created /home/dave/dev/cargo-generate/foo
```