### PR TITLE
Only use cross for linux prebuilt binaries

### DIFF
--- a/.github/workflows/release-binary-assets.yml
+++ b/.github/workflows/release-binary-assets.yml
@@ -58,7 +58,7 @@ jobs:
           tar -czvf "$filename" README.md LICENSE-MIT LICENSE-APACHE -C "target/$TARGET/release" "${{ matrix.binName }}"
           echo "::set-output name=filename::$filename"
       - name: Upload Archive
-        uses: jashandeep-sohi/release-action@main
+        uses: ncipollo/release-action@v1.8.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true

--- a/.github/workflows/release-binary-assets.yml
+++ b/.github/workflows/release-binary-assets.yml
@@ -41,6 +41,12 @@ jobs:
           command: build
           use-cross: ${{ matrix.cross }}
           args: --features vendored-openssl --release --target=${{ matrix.target }}
+      - name: Smoke Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          use-cross: ${{ matrix.cross }}
+          args: --features vendored-openssl --release --target=${{ matrix.target }} -- -V
       - name: Create Archive
         id: archive
         shell: bash

--- a/.github/workflows/release-binary-assets.yml
+++ b/.github/workflows/release-binary-assets.yml
@@ -58,7 +58,7 @@ jobs:
           tar -czvf "$filename" README.md LICENSE-MIT LICENSE-APACHE -C "target/$TARGET/release" "${{ matrix.binName }}"
           echo "::set-output name=filename::$filename"
       - name: Upload Archive
-        uses: ncipollo/release-action@v1
+        uses: jashandeep-sohi/release-action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
@@ -67,3 +67,4 @@ jobs:
           artifactContentType: application/octet-stream
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
+          omitPrereleaseDuringUpdate: true

--- a/.github/workflows/release-binary-assets.yml
+++ b/.github/workflows/release-binary-assets.yml
@@ -12,12 +12,20 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            cross: true
+            binName: cargo-generate
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
+            cross: true
+            binName: cargo-generate
           - target: x86_64-apple-darwin
             os: macos-latest
+            cross: false
+            binName: cargo-generate
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+            cross: false
+            binName: cargo-generate.exe
     steps:
       - uses: actions/checkout@v2
       - name: Setup Rust
@@ -31,7 +39,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          use-cross: true
+          use-cross: ${{ matrix.cross }}
           args: --features vendored-openssl --release --target=${{ matrix.target }}
       - name: Create Archive
         id: archive
@@ -41,7 +49,7 @@ jobs:
           TAG: ${{ github.event.release.tag_name }}
         run: |
           filename="cargo-generate-$TAG-$TARGET.tar.gz"
-          tar -czvf "$filename" README.md LICENSE-MIT LICENSE-APACHE -C "target/$TARGET/release" cargo-generate
+          tar -czvf "$filename" README.md LICENSE-MIT LICENSE-APACHE -C "target/$TARGET/release" "${{ matrix.binName }}"
           echo "::set-output name=filename::$filename"
       - name: Upload Archive
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
@sassman, I'm proposing a few changes to the prebuilt binaries workflow:

- Only use cross for linux builds. It's not really needed for macos & windows. On windows it also causes binaries to be built without the .exe extension.
- Try running running the built binary as a sanity check. Should we also be running tests for each of the targets too?
- Lock down the release action to a specific version & set `omitPrereleaseDuringUpdate` to avoid resetting the pre-release state of a release.