### PR TITLE
Specify values via env vars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,13 +205,13 @@ Since version [0.6.0](https://github.com/cargo-generate/cargo-generate/releases/
 Here [an example](https://github.com/sassman/hermit-template-rs):
 
 ```toml
-[placeholders.hypervisor]
+[placeholders.HYPERVISOR]
 type = "string"
 prompt = "What hypervisor to use?"
 choices = ["uhyve", "qemu"]
 default = "qemu"
 
-[placeholders.network_enabled]
+[placeholders.NETWORK_ENABLED]
 type = "bool"
 prompt = "Want to enable network?"
 default = true
@@ -219,10 +219,10 @@ default = true
 
 As you can see the `placeholders` configuration section accepts a table of keywords that will become the placeholder name.
 
-In this example the placeholder `hypervisor` and `network_enabled` will become template variables and can be used like this:
+In this example the placeholder `HYPERVISOR` and `NETWORK_ENABLED` will become template variables and can be used like this:
 
 ```rs
-{% if network_enabled %}
+{% if NETWORK_ENABLED %}
 use std::net::TcpListener;
 
 fn main() {
@@ -243,8 +243,8 @@ fn main() {
 > Tip: similar to `dependencies` in the `Cargo.toml` file you can also list them as one liners:
 ```toml
 [placeholders]
-hypervisor = { type = "string", prompt = "What hypervisor to use?", choices = ["uhyve", "qemu"], default = "qemu" }
-network_enabled = { type = "bool", prompt = "Want to enable network?", default = true }
+HYPERVISOR = { type = "string", prompt = "What HYPERVISOR to use?", choices = ["uhyve", "qemu"], default = "qemu" }
+NETWORK_ENABLED = { type = "bool", prompt = "Want to enable network?", default = true }
 ```
 
 ### `prompt` property
@@ -252,7 +252,7 @@ network_enabled = { type = "bool", prompt = "Want to enable network?", default =
 The `prompt` will be used to display a question / message for this very placeholder on the interactive dialog when using the template.
 
 ```plain
-🤷  What hypervisor to use? [uhyve, qemu] [default: qemu]:
+🤷  What HYPERVISOR to use? [uhyve, qemu] [default: qemu]:
 ```
 
 ### `type` property
@@ -292,7 +292,21 @@ phone_number = { type = "string", prompt = "What's your phone number?", regex = 
 
 ## Default values for placeholders from a file
 
-For automation purposes the user of the template may provide provide a file containing the values for the keys in the template by using the `--template-values-file` flag.
+For automation purposes the user of the template may provide the values for the keys in the template using one or more of the following methods.
+
+> NOTE: The methods are listed by falling priority
+
+#### `--define` or `-d` flag
+
+The user may specify variables individually using the `--define` flag.
+
+```sh
+cargo generate template-above -n project-name -d HYPERVISOR=qemu -d NETWORK_ENABLED=true
+```
+
+#### <a name="valuesfile"></a> `--template_values_file` flag
+
+The user of the template may provide a file containing the values for the keys in the template by using the `--template-values-file` flag.
 
 > NOTE: A relative path will be relative to current working dir, which is *not* inside the expanding template!
 
@@ -300,17 +314,27 @@ The file should be a toml file containing the following (for the example templat
 
 ```toml
 [values]
-hypervisor = "qemu"
-network_enabled = true
+HYPERVISOR = "qemu"
+NETWORK_ENABLED = true
 ```
 
-Values can also be specified on the command line using the `--define | -d` flag. Values specified like this will override any other.
+#### Individual values via environment variables
+
+Variables may be specified using environment variables. To do so, set the env var `CARGO_GENERATE_VALUE_<variable key>` to the desired value.
 
 ```sh
-cargo generate --git https://github.com/githubusername/mytemplate.git --name myproject --define hypervisor=none -d network_enabled=false
+set CARGO_GENERATE_VALUE_HYPERVISOR=qemu
+set CARGO_GENERATE_VALUE_NETWORK_ENABLED=true
+cargo generate template-above
 ```
 
-If a value has been specified before, the last `-d` of a variable will overide any previous value.
+> :warning: Windows does not like lowercase in environment variables. For that reason we recommend using all uppercase variable names.
+
+#### Template values file via environment variable
+
+As a last resort, the user may use the environment variable `CARGO_GENERATE_TEMPLATE_VALUES` to specify a file with default values.
+
+For the file format, see [above](#valuesfile)
 
 ## Include / Exclude
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cargo install cargo-generate --features vendored-openssl
 
 Standard usage is to pass a `--git` flag to `cargo generate` or short `cargo gen`. This will prompt you to enter the name of your project.
 
-> NOTE: `cargo gen` requires a [cargo alias configuration](#cargo-gen---alias) 
+> NOTE: `cargo gen` requires a [cargo alias configuration](#cargo-gen---alias)
 
 ```sh
 cargo generate --git https://github.com/githubusername/mytemplate.git
@@ -92,12 +92,12 @@ cargo generate --git rustwasm/wasm-pack-template --name mywasm
 
 ## http(s) proxy
 
-New in version [0.7.0] is automatic proxy usage. So, if http(s)\_PROXY env variables are provided, they 
-will be used for cloning a http(s) template repository. 
+New in version [0.7.0] is automatic proxy usage. So, if http(s)\_PROXY env variables are provided, they
+will be used for cloning a http(s) template repository.
 
 ## Favorites
 
-Favorite templates can be defined in a config file, that by default is placed at `$CARGO_HOME/cargo-generate`. 
+Favorite templates can be defined in a config file, that by default is placed at `$CARGO_HOME/cargo-generate`.
 To specify an alternative configuration file, use the `--config <config-file>` option.
 
 > NOTE: A relative `--config` option, will be relative to the template root during expansion.
@@ -134,27 +134,27 @@ Templates are git repositories whose files contain placeholders. The current
 supported placeholders are:
 
 - `{{authors}}`
-  
+
   this will be filled in by a function borrowed from Cargo's source code, that determines your information from Cargo's configuration.
 - `{{project-name}}`
-  
+
   this is supplied by either passing the `--name` flag to the command or working with the interactive CLI to supply a name.
 - `{{crate_name}}`
-  
+
   the snake_case_version of `project-name`
 - `{{crate_type}}`
-  
+
   this is supplied by either passing the `--bin` or `--lib` flag to the command line, contains either `bin` or `lib`, `--bin` is the default
 - `{{os-arch}}`
-  
+
   contains the current operating system and architecture ex: `linux-x86_64`
 
-Additionally, **all filters and tags** of the liquid template language are supported. 
+Additionally, **all filters and tags** of the liquid template language are supported.
 For more information, check out the [Liquid Documentation on `Tags` and `Filters`][liquid].
 
 [liquid]: https://shopify.github.io/liquid
 
-You can use those placeholders in the file and directory names of the generated project.  
+You can use those placeholders in the file and directory names of the generated project.
 For example, for a project named `awesome`, the filename `{{project_name}}/{{project_name}}.rs` will be transformed to `awesome/awesome.rs` during generation.
 Only files that are **not** listed in the exclude settings will be templated.
 
@@ -164,14 +164,14 @@ You can also add a `.genignore` file to your template. The files listed in the `
 will be removed from the local machine when `cargo-generate` is run on the end user's machine.
 The `.genignore` file is always ignored, so there is no need to list it in the `.genignore` file.
 
-> NOTE: 
+> NOTE:
 
 Here's a list of [currently available templates](TEMPLATES.md).
 If you have a great template that you'd like to feature here, please [file an issue or a PR]!
 
 [file an issue or a PR]: https://github.com/cargo-generate/cargo-generate/issues
 
-### Example for `--bin` and `--lib` 
+### Example for `--bin` and `--lib`
 
 A template could be prepared in a way to act as a binary or a library. For example the `Cargo.toml` might look like:
 
@@ -192,26 +192,26 @@ name = "{{crate_name}}-cli"
 {% endif %}
 ```
 
-Now a user of this template could decide weather they want the binary version by passing `--bin` 
+Now a user of this template could decide weather they want the binary version by passing `--bin`
 or use only the library version by passing `--lib` as a command line argument.
 
 ## Template defined placeholders
 
-Sometimes templates need to make decisions. For example one might want to conditionally include some code or not. 
+Sometimes templates need to make decisions. For example one might want to conditionally include some code or not.
 Another use case might be that the user of a template should be able to choose out of provided options in an interactive way.
 Also, it might be helpful to offer a reasonable default value that the user just simply can use.
 
-Since version [0.6.0](https://github.com/cargo-generate/cargo-generate/releases/tag/v0.6.0) it is possible to use placeholders in a `cargo-generate.toml` that is in the root folder of a template.  
+Since version [0.6.0](https://github.com/cargo-generate/cargo-generate/releases/tag/v0.6.0) it is possible to use placeholders in a `cargo-generate.toml` that is in the root folder of a template.
 Here [an example](https://github.com/sassman/hermit-template-rs):
 
 ```toml
-[placeholders.HYPERVISOR]
+[placeholders.hypervisor]
 type = "string"
 prompt = "What hypervisor to use?"
 choices = ["uhyve", "qemu"]
 default = "qemu"
 
-[placeholders.NETWORK_ENABLED]
+[placeholders.network_enabled]
 type = "bool"
 prompt = "Want to enable network?"
 default = true
@@ -219,10 +219,10 @@ default = true
 
 As you can see the `placeholders` configuration section accepts a table of keywords that will become the placeholder name.
 
-In this example the placeholder `HYPERVISOR` and `NETWORK_ENABLED` will become template variables and can be used like this:
+In this example the placeholder `hypervisor` and `network_enabled` will become template variables and can be used like this:
 
 ```rs
-{% if NETWORK_ENABLED %}
+{% if network_enabled %}
 use std::net::TcpListener;
 
 fn main() {
@@ -243,8 +243,8 @@ fn main() {
 > Tip: similar to `dependencies` in the `Cargo.toml` file you can also list them as one liners:
 ```toml
 [placeholders]
-HYPERVISOR = { type = "string", prompt = "What HYPERVISOR to use?", choices = ["uhyve", "qemu"], default = "qemu" }
-NETWORK_ENABLED = { type = "bool", prompt = "Want to enable network?", default = true }
+hypervisor = { type = "string", prompt = "What hypervisor to use?", choices = ["uhyve", "qemu"], default = "qemu" }
+network_enabled = { type = "bool", prompt = "Want to enable network?", default = true }
 ```
 
 ### `prompt` property
@@ -252,7 +252,7 @@ NETWORK_ENABLED = { type = "bool", prompt = "Want to enable network?", default =
 The `prompt` will be used to display a question / message for this very placeholder on the interactive dialog when using the template.
 
 ```plain
-🤷  What HYPERVISOR to use? [uhyve, qemu] [default: qemu]:
+🤷  What hypervisor to use? [uhyve, qemu] [default: qemu]:
 ```
 
 ### `type` property
@@ -261,7 +261,7 @@ A placeholder can be of type `string` or `bool`. Boolean types are usually helpf
 
 ### `choices` property (optional)
 
-A placeholder can come with a list of choices that the user can choose from. 
+A placeholder can come with a list of choices that the user can choose from.
 It's further also validated at the time when a user generates a project from a template.
 
 ```toml
@@ -279,7 +279,7 @@ default = 'qemu'
 
 ### `regex` property (optional)
 
-A `regex` property is a string, that can be used to enforce a certain validation rule. The input dialog will keep repeating 
+A `regex` property is a string, that can be used to enforce a certain validation rule. The input dialog will keep repeating
 until the user entered something that is allowed by this regex.
 
 ### Placeholder Examples
@@ -301,7 +301,7 @@ For automation purposes the user of the template may provide the values for the 
 The user may specify variables individually using the `--define` flag.
 
 ```sh
-cargo generate template-above -n project-name -d HYPERVISOR=qemu -d NETWORK_ENABLED=true
+cargo generate template-above -n project-name -d hypervisor=qemu -d network_enabled=true
 ```
 
 #### <a name="valuesfile"></a> `--template_values_file` flag
@@ -314,8 +314,8 @@ The file should be a toml file containing the following (for the example templat
 
 ```toml
 [values]
-HYPERVISOR = "qemu"
-NETWORK_ENABLED = true
+hypervisor = "qemu"
+network_enabled = true
 ```
 
 #### Individual values via environment variables
@@ -328,7 +328,7 @@ set CARGO_GENERATE_VALUE_NETWORK_ENABLED=true
 cargo generate template-above
 ```
 
-> :warning: Windows does not like lowercase in environment variables. For that reason we recommend using all uppercase variable names.
+> :warning: Windows does not support mixed case environment variables. Internally, `cargo-generate` will ensure the variable name is all lowercase. For that reason, it is strongly recommended that template authors only use lowercase variable/placeholder names.
 
 #### Template values file via environment variable
 
@@ -339,8 +339,8 @@ For the file format, see [above](#valuesfile)
 ## Include / Exclude
 
 Templates support a `cargo-generate.toml`, with a "template" section that allows you to configure the files that will be processed by `cargo-generate`.
-The behavior mirrors Cargo's Include / Exclude functionality, which is [documented here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields-optional). 
-If you are using placeholders in a file name, and also wish to use placeholders in the contents of that file, 
+The behavior mirrors Cargo's Include / Exclude functionality, which is [documented here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields-optional).
+If you are using placeholders in a file name, and also wish to use placeholders in the contents of that file,
 you should setup your globs to match on the pre-rename filename.
 
 ```toml
@@ -354,7 +354,7 @@ The `cargo-generate.toml` file should be placed in the root of the template. If 
 
 ## Cargo gen - alias
 
-`cargo gen` requires an [cargo alias](https://doc.rust-lang.org/cargo/reference/config.html) 
+`cargo gen` requires an [cargo alias](https://doc.rust-lang.org/cargo/reference/config.html)
 to be configured in your `$HOME/.cargo/config` like this:
 
 ```toml

--- a/src/template_variables/mod.rs
+++ b/src/template_variables/mod.rs
@@ -25,7 +25,7 @@ pub(crate) fn resolve_template_values(args: &Args) -> Result<HashMap<String, Val
 
     values.extend(std::env::vars().filter_map(|(key, value)| {
         key.strip_prefix("CARGO_GENERATE_VALUE_")
-            .map(|key| (key.to_owned(), Value::from(value)))
+            .map(|key| (key.to_lowercase(), Value::from(value)))
     }));
 
     values.extend(

--- a/tests/integration/values.rs
+++ b/tests/integration/values.rs
@@ -7,22 +7,33 @@ use assert_cmd::prelude::*;
 use indoc::indoc;
 
 #[test]
-fn it_accepts_template_values_file() {
+fn it_accepts_template_values_from_multiple_places() {
     let template = tmp_dir()
+        .file(
+            "my-env-values.toml",
+            indoc! {r#"
+                [values]
+                MY_VALUE1 = "env-file-value"
+                MY_VALUE2 = "env-file-value"
+                MY_VALUE3 = "env-file-value"
+                MY_VALUE4 = "env-file-value"
+            "#},
+        )
         .file(
             "my-values.toml",
             indoc! {r#"
                 [values]
-                my_value = "content of my-value"
+                MY_VALUE3 = "file-value"
+                MY_VALUE4 = "file-value"
             "#},
         )
         .file(
-            "Cargo.toml",
+            "random.toml",
             indoc! {r#"
-                [package]
-                name = "{{project-name}}"
-                description = "{{my_value}}"
-                version = "0.1.0"
+                value1 = "{{MY_VALUE1}}"
+                value2 = "{{MY_VALUE2}}"
+                value3 = "{{MY_VALUE3}}"
+                value4 = "{{MY_VALUE4}}"
             "#},
         )
         .init_git()
@@ -34,16 +45,29 @@ fn it_accepts_template_values_file() {
         .arg("generate")
         .arg("--name")
         .arg("foobar-project")
+        .arg("--define")
+        .arg("MY_VALUE4=def-value")
+        .arg("--git")
+        .arg(template.path())
         .arg("--template-values-file")
         .arg(template.path().join("my-values.toml"))
-        .arg(template.path())
         .current_dir(&dir.path())
+        .env(
+            "CARGO_GENERATE_TEMPLATE_VALUES_FILE",
+            template.path().join("my-env-values.toml"),
+        )
+        .env("CARGO_GENERATE_VALUE_MY_VALUE2", "env-def-value")
+        .env("CARGO_GENERATE_VALUE_MY_VALUE3", "env-def-value")
+        .env("CARGO_GENERATE_VALUE_MY_VALUE4", "env-def-value")
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
 
-    let cargo_toml = dir.read("foobar-project/Cargo.toml");
-    assert!(cargo_toml.contains("content of my-value"));
+    let random_toml = dbg!(dir.read("foobar-project/random.toml"));
+    assert!(random_toml.contains("value1 = \"env-file-value\""));
+    assert!(random_toml.contains("value2 = \"env-def-value\""));
+    assert!(random_toml.contains("value3 = \"file-value\""));
+    assert!(random_toml.contains("value4 = \"def-value\""));
 }
 
 #[test]

--- a/tests/integration/values.rs
+++ b/tests/integration/values.rs
@@ -13,13 +13,13 @@ fn it_accepts_template_values_file_from_environment() {
             "my-env-values.toml",
             indoc! {r#"
                 [values]
-                MY_VALUE = "env-file-value"
+                my_value = "env-file-value"
             "#},
         )
         .file(
             "random.toml",
             indoc! {r#"
-                value = "{{MY_VALUE}}"
+                value = "{{my_value}}"
             "#},
         )
         .init_git()
@@ -53,13 +53,13 @@ fn it_accepts_individual_template_values_from_environment() {
             "my-env-values.toml",
             indoc! {r#"
                 [values]
-                MY_VALUE = "env-file-value"
+                my_value = "env-file-value"
             "#},
         )
         .file(
             "random.toml",
             indoc! {r#"
-                value = "{{MY_VALUE}}"
+                value = "{{my_value}}"
             "#},
         )
         .init_git()
@@ -94,13 +94,13 @@ fn it_accepts_template_values_file_via_flag() {
             "my-values.toml",
             indoc! {r#"
                 [values]
-                MY_VALUE = "file-value"
+                my_value = "file-value"
             "#},
         )
         .file(
             "random.toml",
             indoc! {r#"
-                value = "{{MY_VALUE}}"
+                value = "{{my_value}}"
             "#},
         )
         .init_git()
@@ -133,13 +133,13 @@ fn it_accepts_individual_template_values_via_flag() {
             "my-values.toml",
             indoc! {r#"
                 [values]
-                MY_VALUE = "file-value"
+                my_value = "file-value"
             "#},
         )
         .file(
             "random.toml",
             indoc! {r#"
-                value = "{{MY_VALUE}}"
+                value = "{{my_value}}"
             "#},
         )
         .init_git()
@@ -156,7 +156,7 @@ fn it_accepts_individual_template_values_via_flag() {
         .arg("--template-values-file")
         .arg(template.path().join("my-values.toml"))
         .arg("--define")
-        .arg("MY_VALUE=def-value")
+        .arg("my_value=def-value")
         .current_dir(&dir.path())
         .assert()
         .success()


### PR DESCRIPTION
Relates to #389

- Accepts env var `CARGO_GENERATE_TEMPLATE_VALUES_FILE` to specify the `template-values-file` option.
- Accept env vars on the form `CARGO_GENERATE_VALUE_<key>`, to set individual values (akin to `--define`)

> NOTE: Windows does **not** support passing in values for lowercase variables via the environment variables. Windows insist on using uppercase for all ENV vars.