### PR TITLE
Introduce `--path` flag

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -22,6 +22,7 @@ pub(crate) struct FavoriteConfig {
     pub git: Option<String>,
     pub branch: Option<String>,
     pub subfolder: Option<String>,
+    pub path: Option<PathBuf>,
 }
 
 impl Default for AppConfig {

--- a/src/args.rs
+++ b/src/args.rs
@@ -39,6 +39,16 @@ pub struct Args {
     #[structopt(short, long, conflicts_with = "subfolder")]
     pub git: Option<String>,
 
+    /// Local path to copy the template from. Can not be specified together with --git.
+    #[structopt(
+        short,
+        long,
+        conflicts_with = "git",
+        conflicts_with = "favorite",
+        conflicts_with = "subfolder"
+    )]
+    pub path: Option<PathBuf>,
+
     /// Branch to use when installing from git
     #[structopt(short, long)]
     pub branch: Option<String>,

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,124 @@
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use anyhow::{anyhow, Result};
+use structopt::StructOpt;
+
+use crate::git;
+
+#[derive(StructOpt)]
+#[structopt(bin_name = "cargo")]
+pub enum Cli {
+    #[structopt(name = "generate", visible_alias = "gen")]
+    Generate(Args),
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Args {
+    /// List defined favorite templates from the config
+    #[structopt(long)]
+    pub list_favorites: bool,
+
+    /// Generate a favorite template as defined in the config. In case the favorite is undefined,
+    /// use in place of the `--git` option, otherwise specifies the subfolder
+    #[structopt(name = "favorite|git|subfolder")]
+    pub favorite: Option<String>,
+
+    /// Specifies a subfolder within the template repository to be used as the actual template.
+    #[structopt()]
+    pub subfolder: Option<String>,
+
+    /// Git repository to clone template from. Can be a URL (like
+    /// `https://github.com/rust-cli/cli-template`), a path (relative or absolute), or an
+    /// `owner/repo` abbreviated GitHub URL (like `rust-cli/cli-template`).
+    ///
+    /// Note that cargo generate will first attempt to interpret the `owner/repo` form as a
+    /// relative path and only try a GitHub URL if the local path doesn't exist.
+    #[structopt(short, long, conflicts_with = "subfolder")]
+    pub git: Option<String>,
+
+    /// Branch to use when installing from git
+    #[structopt(short, long)]
+    pub branch: Option<String>,
+
+    /// Directory to create / project name; if the name isn't in kebab-case, it will be converted
+    /// to kebab-case unless `--force` is given.
+    #[structopt(long, short)]
+    pub name: Option<String>,
+
+    /// Don't convert the project name to kebab-case before creating the directory.
+    /// Note that cargo generate won't overwrite an existing directory, even if `--force` is given.
+    #[structopt(long, short)]
+    pub force: bool,
+
+    /// Enables more verbose output.
+    #[structopt(long, short)]
+    pub verbose: bool,
+
+    /// Pass template values through a file
+    /// Values should be in the format `key=value`, one per line
+    #[structopt(long)]
+    pub template_values_file: Option<String>,
+
+    /// If silent mode is set all variables will be
+    /// extracted from the template_values_file.
+    /// If a value is missing the project generation will fail
+    #[structopt(long, short, requires("name"))]
+    pub silent: bool,
+
+    /// Use specific configuration file. Defaults to $CARGO_HOME/cargo-generate or $HOME/.cargo/cargo-generate
+    #[structopt(short, long, parse(from_os_str))]
+    pub config: Option<PathBuf>,
+
+    /// Specify the VCS used to initialize the generated template.
+    #[structopt(long, default_value = "git")]
+    pub vcs: Vcs,
+
+    /// Populates a template variable `crate_type` with value `"lib"`
+    #[structopt(long, conflicts_with = "bin")]
+    pub lib: bool,
+
+    /// Populates a template variable `crate_type` with value `"bin"`
+    #[structopt(long, conflicts_with = "lib")]
+    pub bin: bool,
+
+    /// Use a different ssh identity
+    #[structopt(short = "i", long = "identity", parse(from_os_str))]
+    pub ssh_identity: Option<PathBuf>,
+
+    /// Define a value for use during template expansion
+    #[structopt(long, short, number_of_values = 1)]
+    pub define: Vec<String>,
+}
+
+#[derive(Debug, StructOpt, Clone, Copy)]
+pub enum Vcs {
+    None,
+    Git,
+}
+
+impl FromStr for Vcs {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "NONE" => Ok(Vcs::None),
+            "GIT" => Ok(Vcs::Git),
+            _ => Err(anyhow!("Must be one of 'git' or 'none'")),
+        }
+    }
+}
+
+impl Vcs {
+    pub fn initialize(&self, project_dir: &Path, branch: String) -> Result<()> {
+        match self {
+            Vcs::None => {}
+            Vcs::Git => {
+                git::init(project_dir, &branch)?;
+            }
+        };
+        Ok(())
+    }
+}

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -48,12 +48,16 @@ pub(crate) fn resolve_favorite_args(app_config: &AppConfig, args: &mut Args) -> 
         return Ok(());
     }
 
+    if args.path.is_some() {
+        return Ok(());
+    }
+
     let favorite_name = args
         .favorite
         .as_ref()
         .ok_or_else(|| anyhow!("Please specify either --git option, or a predefined favorite"))?;
 
-    let (git, branch, subfolder) = app_config
+    let (git, branch, subfolder, path) = app_config
         .favorites
         .get(favorite_name.as_str())
         .map_or_else(
@@ -66,6 +70,7 @@ pub(crate) fn resolve_favorite_args(app_config: &AppConfig, args: &mut Args) -> 
                     Some(favorite_name.clone()),
                     args.branch.as_ref().cloned(),
                     args.subfolder.clone(),
+                    None,
                 )
             },
             |f| {
@@ -76,6 +81,7 @@ pub(crate) fn resolve_favorite_args(app_config: &AppConfig, args: &mut Args) -> 
                         .as_ref()
                         .or_else(|| f.subfolder.as_ref())
                         .cloned(),
+                    f.path.clone(),
                 )
             },
         );
@@ -83,6 +89,7 @@ pub(crate) fn resolve_favorite_args(app_config: &AppConfig, args: &mut Args) -> 
     args.git = git;
     args.branch = branch;
     args.subfolder = subfolder;
+    args.path = path;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@
 //! `os-arch` and `authors` also can't be overriden and are derived from the environment.
 
 mod app_config;
+mod args;
 mod config;
 mod emoji;
 mod favorites;
@@ -93,6 +94,8 @@ mod project_variables;
 mod template;
 mod template_variables;
 
+pub use args::*;
+
 use anyhow::{anyhow, bail, Context, Result};
 use config::{Config, CONFIG_FILE_NAME};
 use console::style;
@@ -102,9 +105,8 @@ use std::{
     collections::HashMap,
     env, fs,
     path::{Path, PathBuf},
-    str::FromStr,
 };
-use structopt::StructOpt;
+
 use tempfile::TempDir;
 
 use crate::{
@@ -112,121 +114,6 @@ use crate::{
     template_variables::{CrateType, ProjectName},
 };
 use crate::{git::GitConfig, template_variables::resolve_template_values};
-
-#[derive(StructOpt)]
-#[structopt(bin_name = "cargo")]
-pub enum Cli {
-    #[structopt(name = "generate", visible_alias = "gen")]
-    Generate(Args),
-}
-
-#[derive(Debug, StructOpt)]
-pub struct Args {
-    /// List defined favorite templates from the config
-    #[structopt(long)]
-    pub list_favorites: bool,
-
-    /// Generate a favorite template as defined in the config. In case the favorite is undefined,
-    /// use in place of the `--git` option, otherwise specifies the subfolder
-    #[structopt(name = "favorite|git|subfolder")]
-    pub favorite: Option<String>,
-
-    /// Specifies a subfolder within the template repository to be used as the actual template.
-    #[structopt()]
-    pub subfolder: Option<String>,
-
-    /// Git repository to clone template from. Can be a URL (like
-    /// `https://github.com/rust-cli/cli-template`), a path (relative or absolute), or an
-    /// `owner/repo` abbreviated GitHub URL (like `rust-cli/cli-template`).
-    ///
-    /// Note that cargo generate will first attempt to interpret the `owner/repo` form as a
-    /// relative path and only try a GitHub URL if the local path doesn't exist.
-    #[structopt(short, long, conflicts_with = "subfolder")]
-    pub git: Option<String>,
-
-    /// Branch to use when installing from git
-    #[structopt(short, long)]
-    pub branch: Option<String>,
-
-    /// Directory to create / project name; if the name isn't in kebab-case, it will be converted
-    /// to kebab-case unless `--force` is given.
-    #[structopt(long, short)]
-    pub name: Option<String>,
-
-    /// Don't convert the project name to kebab-case before creating the directory.
-    /// Note that cargo generate won't overwrite an existing directory, even if `--force` is given.
-    #[structopt(long, short)]
-    pub force: bool,
-
-    /// Enables more verbose output.
-    #[structopt(long, short)]
-    pub verbose: bool,
-
-    /// Pass template values through a file
-    /// Values should be in the format `key=value`, one per line
-    #[structopt(long)]
-    pub template_values_file: Option<String>,
-
-    /// If silent mode is set all variables will be
-    /// extracted from the template_values_file.
-    /// If a value is missing the project generation will fail
-    #[structopt(long, short, requires("name"))]
-    pub silent: bool,
-
-    /// Use specific configuration file. Defaults to $CARGO_HOME/cargo-generate or $HOME/.cargo/cargo-generate
-    #[structopt(short, long, parse(from_os_str))]
-    pub config: Option<PathBuf>,
-
-    /// Specify the VCS used to initialize the generated template.
-    #[structopt(long, default_value = "git")]
-    pub vcs: Vcs,
-
-    /// Populates a template variable `crate_type` with value `"lib"`
-    #[structopt(long, conflicts_with = "bin")]
-    pub lib: bool,
-
-    /// Populates a template variable `crate_type` with value `"bin"`
-    #[structopt(long, conflicts_with = "lib")]
-    pub bin: bool,
-
-    /// Use a different ssh identity
-    #[structopt(short = "i", long = "identity", parse(from_os_str))]
-    pub ssh_identity: Option<PathBuf>,
-
-    /// Define a value for use during template expansion
-    #[structopt(long, short, number_of_values = 1)]
-    pub define: Vec<String>,
-}
-
-#[derive(Debug, StructOpt, Clone, Copy)]
-pub enum Vcs {
-    None,
-    Git,
-}
-
-impl FromStr for Vcs {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_uppercase().as_str() {
-            "NONE" => Ok(Vcs::None),
-            "GIT" => Ok(Vcs::Git),
-            _ => Err(anyhow!("Must be one of 'git' or 'none'")),
-        }
-    }
-}
-
-impl Vcs {
-    fn initialize(&self, project_dir: &Path, branch: String) -> Result<()> {
-        match self {
-            Vcs::None => {}
-            Vcs::Git => {
-                git::init(project_dir, &branch)?;
-            }
-        };
-        Ok(())
-    }
-}
 
 pub fn generate(mut args: Args) -> Result<()> {
     let path = &app_config_path(&args.config)?;

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -43,6 +43,37 @@ version = "0.1.0"
 }
 
 #[test]
+fn it_can_use_a_specified_path() {
+    let template = tmp_dir()
+        .file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .build();
+
+    let dir = tmp_dir().build();
+
+    binary()
+        .arg("generate")
+        .arg("--name")
+        .arg("foobar-project")
+        .arg("--path")
+        .arg(template.path())
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    let repo = git2::Repository::open(&dir.path().join("foobar-project")).unwrap();
+    let references = repo.references().unwrap().count();
+    assert_eq!(0, references);
+}
+
+#[test]
 fn it_removes_git_history() {
     let template = tmp_dir()
         .file(

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -19,6 +19,7 @@ version = "0.1.0"
 
     let args_exposed: Args = Args {
         git: Some(format!("{}", template.path().display())),
+        path: None,
         branch: Some(String::from("main")),
         subfolder: None,
         name: Some(String::from("foobar_project")),


### PR DESCRIPTION
Closes #406
Relates to #47 

Introduce `--path <path>` to use a local folder as the template.

This solves the issue of being unable to use a local 'dirty' git repo as the template. This would e.g. be the case during template development if the developer doesn't commit between each retry (which seems like a very likely scenario).
