### PR TITLE
fix(tests:linux): use the current directory for canonicalize result

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -103,9 +103,13 @@ fn should_canonicalize() {
         .unwrap()
         .starts_with("/Users/"));
     #[cfg(target_os = "linux")]
-    assert!(canonicalize_path(&PathBuf::from("../"))
-        .unwrap()
-        .starts_with("/home/"));
+    assert_eq!(
+        canonicalize_path(&PathBuf::from("../")).ok(),
+        std::env::current_dir()
+            .unwrap()
+            .parent()
+            .map(|p| p.to_path_buf())
+    );
     #[cfg(windows)]
     assert!(canonicalize_path(&PathBuf::from("../"))
         .unwrap()


### PR DESCRIPTION
This PR removes the assumption from `should_canonicalize` test that is always being run in a subdirectory which is in `/home`.

For example, while building `cargo-generate` for Arch Linux in a clean chroot, tests are being run in `/build/cargo-generate/src` and this canonicalize test is failing as expected:

```
thread 'git::should_canonicalize' panicked at 'assertion failed: canonicalize_path(&PathBuf::from(\"../\")).unwrap().starts_with(\"/home/\")', src/git.rs:106:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

