### PR TITLE
feat(template:parsing): handle undefined variables gracefully

### DIFF
--- a/src/filenames.rs
+++ b/src/filenames.rs
@@ -1,5 +1,6 @@
 use crate::Result;
 
+use crate::template::render_string_gracefully;
 use liquid::{Object, Parser};
 use std::path::{Component, Path, PathBuf};
 
@@ -8,7 +9,7 @@ pub fn substitute_filename(filepath: &Path, parser: &Parser, context: &Object) -
     for elem in filepath.components() {
         match elem {
             Component::Normal(e) => {
-                let parsed = parser.parse(e.to_str().unwrap())?.render(context)?;
+                let parsed = render_string_gracefully(context, parser, e.to_str().unwrap())?;
                 let parsed = sanitize_filename(parsed.as_str());
                 path.push(parsed);
             }

--- a/src/template.rs
+++ b/src/template.rs
@@ -16,6 +16,8 @@ use crate::include_exclude::*;
 use crate::progressbar::spinner;
 use crate::template_variables::{get_authors, get_os_arch, Authors, CrateType, ProjectName};
 
+use liquid::Parser;
+
 fn engine() -> liquid::Parser {
     liquid::ParserBuilder::with_stdlib()
         .filter(KebabCaseFilterParser)
@@ -166,6 +168,7 @@ pub(crate) fn walk_dir(
     )?;
     let spinner_style = spinner();
 
+    let mut files_with_errors = Vec::new();
     let files = WalkDir::new(project_dir)
         .sort_by_file_name()
         .contents_first(true)
@@ -190,44 +193,43 @@ pub(crate) fn walk_dir(
         let f = relative_path.display();
         pb.set_message(format!("Processing: {}", f));
 
+        // todo(refactor): as parameter
+        let verbose = false;
+
         if matcher.should_include(relative_path) {
             if entry.file_type().is_file() {
-                let new_contents = engine
-                    .clone()
-                    .parse_file(filename)?
-                    .render(&template)
-                    .with_context(|| {
-                        format!(
-                            "{} {} `{}`",
-                            emoji::ERROR,
-                            style("Error replacing placeholders").bold().red(),
-                            style(filename.display()).bold()
-                        )
-                    })?;
-                pb.inc(25);
-                let new_filename =
-                    substitute_filename(filename, &engine, &template).with_context(|| {
-                        format!(
-                            "{} {} `{}`",
-                            emoji::ERROR,
-                            style("Error templating a filename").bold().red(),
-                            style(filename.display()).bold()
-                        )
-                    })?;
-                pb.inc(25);
-                let relative_path = new_filename.strip_prefix(project_dir)?;
-                let f = relative_path.display();
-                fs::create_dir_all(new_filename.parent().unwrap()).unwrap();
-                fs::write(new_filename.as_path(), new_contents).with_context(|| {
-                    format!(
-                        "{} {} `{}`",
-                        emoji::ERROR,
-                        style("Error writing").bold().red(),
-                        style(new_filename.display()).bold()
-                    )
-                })?;
-                pb.inc(50);
-                pb.finish_with_message(format!("Done: {}", f));
+                match template_process_file(&template, &engine, filename) {
+                    Err(e) => {
+                        if verbose {
+                            files_with_errors.push((filename.display().to_string(), e.clone()));
+                        }
+                    }
+                    Ok(new_contents) => {
+                        let new_filename = substitute_filename(filename, &engine, &template)
+                            .with_context(|| {
+                                format!(
+                                    "{} {} `{}`",
+                                    emoji::ERROR,
+                                    style("Error templating a filename").bold().red(),
+                                    style(filename.display()).bold()
+                                )
+                            })?;
+                        pb.inc(25);
+                        let relative_path = new_filename.strip_prefix(project_dir)?;
+                        let f = relative_path.display();
+                        fs::create_dir_all(new_filename.parent().unwrap()).unwrap();
+                        fs::write(new_filename.as_path(), new_contents).with_context(|| {
+                            format!(
+                                "{} {} `{}`",
+                                emoji::ERROR,
+                                style("Error writing rendered file.").bold().red(),
+                                style(new_filename.display()).bold()
+                            )
+                        })?;
+                        pb.inc(50);
+                        pb.finish_with_message(format!("Done: {}", f));
+                    }
+                }
             } else {
                 let new_filename = substitute_filename(filename, &engine, &template)?;
                 let relative_path = new_filename.strip_prefix(project_dir)?;
@@ -243,5 +245,85 @@ pub(crate) fn walk_dir(
             pb.finish_with_message(format!("Skipped: {}", f));
         }
     }
+
+    if !files_with_errors.is_empty() {
+        print_files_with_errors_warning(files_with_errors);
+    }
+
     Ok(())
+}
+
+fn template_process_file(
+    context: &Object,
+    parser: &Parser,
+    file: &Path,
+) -> liquid_core::Result<String> {
+    let content =
+        fs::read_to_string(file).map_err(|e| liquid_core::Error::with_msg(e.to_string()))?;
+    render_string_gracefully(context, parser, content.as_str())
+}
+
+pub fn render_string_gracefully(
+    context: &Object,
+    parser: &Parser,
+    content: &str,
+) -> liquid_core::Result<String> {
+    let template = parser.parse(content)?;
+
+    match template.render(context) {
+        Ok(content) => Ok(content),
+        Err(e) => {
+            // handle it gracefully
+            let msg = e.to_string();
+            if msg.contains("requested variable") {
+                // so, we miss a variable that is present in the file to render
+                let requested_var =
+                    regex::Regex::new(r"(?P<p>.*requested\svariable=)(?P<v>.*)").unwrap();
+                let captures = requested_var.captures(msg.as_str()).unwrap();
+
+                if let Some(Some(req_var)) = captures.iter().last() {
+                    let missing_variable = req_var.as_str().to_string();
+                    // try again with this variable added to the context
+                    let mut context = context.clone();
+                    context.insert(missing_variable.into(), Value::scalar("".to_string()));
+
+                    // now let's parse again to see if we have all variables declared now
+                    return render_string_gracefully(&context, parser, content);
+                }
+            }
+            // todo: find nice way to have this happening outside of this fn
+            // println!(
+            //     "{} {} `{}`",
+            //     emoji::ERROR,
+            //     style("Error rendering template, file has been copied without rendering.")
+            //         .bold()
+            //         .red(),
+            //     style(filename.display()).bold()
+            // );
+            // todo: end
+
+            // fallback: no rendering, keep things original
+            Ok(content.to_string())
+        }
+    }
+}
+
+fn print_files_with_errors_warning(files_with_errors: Vec<(String, liquid_core::Error)>) {
+    let mut msg = format!(
+        "\n{} {}",
+        emoji::WARN,
+        style("Substitution skipped, found invalid syntax in\n")
+            .bold()
+            .red(),
+    );
+    for file_error in files_with_errors {
+        msg.push('\t');
+        msg.push_str(&file_error.0);
+        msg.push('\n');
+    }
+    let read_more =
+        "Learn more: https://github.com/cargo-generate/cargo-generate#include--exclude.\n\n";
+    let hint = style("Consider adding these files to a `cargo-generate.toml` in the template repo to skip substitution on these files.").bold();
+
+    println!("{}\n{}\n\n{}", msg, hint, read_more);
 }


### PR DESCRIPTION
this PR replaces the first draft at #245 also it fixes #204 and #205

it handles:
 - undefined, but from a template requested variables cases harm, especially when a file contains a lot of them but was not excluded from parsing
 - this PR addresses this issue by keeping unknown variables are they are, so that essentially files are partially processed after all
 - matching variables are replaced undefined variables are ignored and kept as they were originally