### PR TITLE
feat: enable paging for long choice lists

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -3,7 +3,7 @@ use crate::{
     project_variables::{StringEntry, TemplateSlots, VarInfo},
 };
 use anyhow::Result;
-use console::style;
+use console::{style, Term};
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Input;
 use liquid_core::Value;
@@ -62,6 +62,7 @@ fn prompt_for_variable(variable: &TemplateSlots) -> Result<String> {
                 0
             };
             let chosen = Select::with_theme(&ColorfulTheme::default())
+                .paged(choices.len() > Term::stdout().size().0 as usize)
                 .items(choices)
                 .with_prompt(&prompt)
                 .default(default)


### PR DESCRIPTION
while waiting for mitsuhiko/dialoguer#125, manually enable paging in dialoguer.

Related to #400 

Still feel like we should wait until `dialoguer` make their next relase for closing #400 though, as we should enable `fuzzy-search` too (already on their master)