### PR TITLE
ci: add documentation check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
 #          known_hosts: ${{ secrets.KNOWN_HOSTS }}
 #          if_key_exists: replace # replace / ignore / fail; optional (defaults to fail)
       - name: cargo test
-        run: cargo test --all --locked -- -Z unstable-options
+        run: cargo test --workspace --locked -- -Z unstable-options
 
   audit:
     name: security audit
@@ -108,7 +108,7 @@ jobs:
         continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          
+
   publish-dry-run:
     name: publish dry run
     runs-on: ubuntu-latest
@@ -122,3 +122,20 @@ jobs:
           profile: minimal
       - uses: Swatinem/rust-cache@v1
       - run: cargo publish --dry-run
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup | rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal
+      - uses: Swatinem/rust-cache@v1
+      - name: check documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps --document-private-items --all-features --workspace

--- a/src/git.rs
+++ b/src/git.rs
@@ -171,7 +171,7 @@ fn pretty_path(a: &Path) -> Result<String> {
 }
 
 /// thanks to @extrawurst for pointing this out
-/// https://github.com/extrawurst/gitui/blob/master/asyncgit/src/sync/branch/mod.rs#L38
+/// <https://github.com/extrawurst/gitui/blob/master/asyncgit/src/sync/branch/mod.rs#L38>
 fn get_branch_name_repo(repo: &Repository) -> Result<String> {
     let iter = repo.branches(None)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,15 @@
 //!
 //! Right now, only git repositories can be used as templates. Just execute
 //!
+//! ```sh
 //! $ cargo generate --git https://github.com/user/template.git --name foo
+//! ```
 //!
 //! or
 //!
+//! ```sh
 //! $ cargo gen --git https://github.com/user/template.git --name foo
+//! ```
 //!
 //! and a new Cargo project called foo will be generated.
 //!
@@ -17,7 +21,7 @@
 //! - `project-name`: Name of the project, in dash-case
 //!
 //! - `crate_name`: Name of the project, but in a case valid for a Rust
-//!   identifier, i.e., snake_case
+//!   identifier, i.e., `snake_case`
 //!
 //! - `authors`: Author names, taken from usual environment variables (i.e.
 //!   those which are also used by Cargo and git)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,29 +2,6 @@ use anyhow::Result;
 use cargo_generate::{generate, Cli};
 use structopt::StructOpt;
 
-/// Generate a new Cargo project from a given template
-///
-/// Right now, only git repositories can be used as templates. Just execute
-///
-/// $ cargo generate --git https://github.com/user/template.git --name foo
-///
-/// or
-///
-/// $ cargo gen --git https://github.com/user/template.git --name foo
-///
-/// and a new Cargo project called foo will be generated.
-///
-/// TEMPLATES:
-///
-/// In templates, the following placeholders can be used:
-///
-/// - `project-name`: Name of the project, in dash-case
-///
-/// - `crate_name`: Name of the project, but in a case valid for a Rust
-///   identifier, i.e., snake_case
-///
-/// - `authors`: Author names, taken from usual environment variables (i.e.
-///   those which are also used by Cargo and git)
 fn main() -> Result<()> {
     let Cli::Generate(args) = Cli::from_args();
     generate(args)?;

--- a/src/template_variables/authors.rs
+++ b/src/template_variables/authors.rs
@@ -6,7 +6,7 @@ pub(crate) type Authors = String;
 
 /// Taken from cargo and thus (c) 2020 Cargo Developers
 ///
-/// cf. https://github.com/rust-lang/cargo/blob/2d5c2381e4e50484bf281fc1bfe19743aa9eb37a/src/cargo/ops/cargo_new.rs#L769-L851
+/// cf. <https://github.com/rust-lang/cargo/blob/2d5c2381e4e50484bf281fc1bfe19743aa9eb37a/src/cargo/ops/cargo_new.rs#L769-L851>
 pub(crate) fn get_authors() -> Result<Authors> {
     fn get_environment_variable(variables: &[&str]) -> Option<String> {
         variables.iter().filter_map(|var| env::var(var).ok()).next()


### PR DESCRIPTION
I also:
- removed `--all` which is deprecated, in favor of `--workspace`
- surrounded with `<>` the markdown links, so that they are clickable from the docs
- removed duplicate documentation in main.rs, which is available in lib.rs