### PR TITLE
README: improve cargo_generate_version example

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Using the supported `cargo-generate.toml` file, the template author may setup ve
 
 ```toml
 [template]
-cargo_generate_version = ">0.8.0"
+cargo_generate_version = ">=0.8.0"
 ```
 
 The format for the version requirement is [documented here](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html).
@@ -399,7 +399,7 @@ The format for the version requirement is [documented here](https://doc.rust-lan
 
 ## Cargo gen - alias
 
-`cargo gen` requires an [cargo alias](https://doc.rust-lang.org/cargo/reference/config.html)
+`cargo gen` requires a [cargo alias](https://doc.rust-lang.org/cargo/reference/config.html)
 to be configured in your `$HOME/.cargo/config` like this:
 
 ```toml


### PR DESCRIPTION
I think that having a version specified as `">=0.8.0"` is more common than `">0.8.0"`.
Maybe in the copy paste, one may forget to add the `=` and this can lead to an error.