### PR TITLE
refactor: add more clippy warnings

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -9,16 +9,16 @@ use std::{
 
 use crate::emoji;
 
-pub(crate) const CONFIG_FILE_NAME: &str = "cargo-generate.toml";
+pub const CONFIG_FILE_NAME: &str = "cargo-generate.toml";
 
 #[derive(Deserialize)]
-pub(crate) struct AppConfig {
+pub struct AppConfig {
     pub favorites: Option<HashMap<String, FavoriteConfig>>,
     pub values: Option<HashMap<String, toml::Value>>,
 }
 
 #[derive(Deserialize, Default)]
-pub(crate) struct FavoriteConfig {
+pub struct FavoriteConfig {
     pub description: Option<String>,
     pub git: Option<String>,
     pub branch: Option<String>,
@@ -37,11 +37,11 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
-    pub(crate) fn from_path(path: &Path) -> Result<AppConfig> {
+    pub(crate) fn from_path(path: &Path) -> Result<Self> {
         if path.exists() {
             let cfg = fs::read_to_string(path)?;
             Ok(if cfg.trim().is_empty() {
-                AppConfig::default()
+                Self::default()
             } else {
                 println!(
                     "{} {} {}",
@@ -61,7 +61,7 @@ impl AppConfig {
     }
 }
 
-pub(crate) fn app_config_path(path: &Option<PathBuf>) -> Result<PathBuf> {
+pub fn app_config_path(path: &Option<PathBuf>) -> Result<PathBuf> {
     path.clone()
         .or_else(|| {
             home::cargo_home().map_or(None, |home| {

--- a/src/args.rs
+++ b/src/args.rs
@@ -134,8 +134,8 @@ impl FromStr for Vcs {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_uppercase().as_str() {
-            "NONE" => Ok(Vcs::None),
-            "GIT" => Ok(Vcs::Git),
+            "NONE" => Ok(Self::None),
+            "GIT" => Ok(Self::Git),
             _ => Err(anyhow!("Must be one of 'git' or 'none'")),
         }
     }
@@ -144,8 +144,8 @@ impl FromStr for Vcs {
 impl Vcs {
     pub fn initialize(&self, project_dir: &Path, branch: String) -> Result<()> {
         match self {
-            Vcs::None => {}
-            Vcs::Git => {
+            Self::None => {}
+            Self::Git => {
                 git::init(project_dir, &branch)?;
             }
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,34 +6,34 @@ use std::path::Path;
 use std::{collections::HashMap, fs};
 use std::{convert::TryFrom, io::ErrorKind};
 
-pub(crate) const CONFIG_FILE_NAME: &str = "cargo-generate.toml";
+pub const CONFIG_FILE_NAME: &str = "cargo-generate.toml";
 
 #[derive(Deserialize, Debug, PartialEq)]
-pub(crate) struct Config {
-    pub(crate) template: Option<TemplateConfig>,
-    pub(crate) placeholders: Option<TemplateSlotsTable>,
+pub struct Config {
+    pub template: Option<TemplateConfig>,
+    pub placeholders: Option<TemplateSlotsTable>,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]
-pub(crate) struct ConfigValues {
-    pub(crate) values: HashMap<String, toml::Value>,
+pub struct ConfigValues {
+    pub values: HashMap<String, toml::Value>,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]
-pub(crate) struct TemplateConfig {
-    pub(crate) cargo_generate_version: Option<VersionReq>,
-    pub(crate) include: Option<Vec<String>>,
-    pub(crate) exclude: Option<Vec<String>>,
+pub struct TemplateConfig {
+    pub cargo_generate_version: Option<VersionReq>,
+    pub include: Option<Vec<String>>,
+    pub exclude: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]
-pub(crate) struct TemplateSlotsTable(pub(crate) HashMap<String, toml::Value>);
+pub struct TemplateSlotsTable(pub HashMap<String, toml::Value>);
 
 impl TryFrom<String> for Config {
     type Error = toml::de::Error;
 
     fn try_from(contents: String) -> Result<Self, Self::Error> {
-        let mut config: Config = toml::from_str(&contents)?;
+        let mut config: Self = toml::from_str(&contents)?;
 
         if let Some(ref mut template) = config.template {
             if template.include.is_some() && template.exclude.is_some() {
@@ -59,7 +59,7 @@ impl Config {
     {
         match path {
             Some(path) => match fs::read_to_string(path) {
-                Ok(contents) => Config::try_from(contents)
+                Ok(contents) => Self::try_from(contents)
                     .map(Option::from)
                     .map_err(|e| e.into()),
                 Err(e) => match e.kind() {

--- a/src/emoji.rs
+++ b/src/emoji.rs
@@ -1,9 +1,9 @@
 use console::Emoji;
 
-pub(crate) static ERROR: Emoji<'_, '_> = Emoji("⛔  ", "");
-pub(crate) static SPARKLE: Emoji<'_, '_> = Emoji("✨  ", "");
-pub(crate) static WARN: Emoji<'_, '_> = Emoji("⚠️  ", "");
-pub(crate) static WRENCH: Emoji<'_, '_> = Emoji("🔧  ", "");
-pub(crate) static SHRUG: Emoji<'_, '_> = Emoji("🤷  ", "");
-pub(crate) static INFO: Emoji<'_, '_> = Emoji("💡  ", "");
-pub(crate) static DIAMOND: Emoji<'_, '_> = Emoji("🔸  ", "");
+pub static ERROR: Emoji<'_, '_> = Emoji("⛔  ", "");
+pub static SPARKLE: Emoji<'_, '_> = Emoji("✨  ", "");
+pub static WARN: Emoji<'_, '_> = Emoji("⚠️  ", "");
+pub static WRENCH: Emoji<'_, '_> = Emoji("🔧  ", "");
+pub static SHRUG: Emoji<'_, '_> = Emoji("🤷  ", "");
+pub static INFO: Emoji<'_, '_> = Emoji("💡  ", "");
+pub static DIAMOND: Emoji<'_, '_> = Emoji("🔸  ", "");

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -7,7 +7,7 @@ use crate::{
 use anyhow::{anyhow, Result};
 use console::style;
 
-pub(crate) fn list_favorites(app_config: &AppConfig, args: &Args) -> Result<()> {
+pub fn list_favorites(app_config: &AppConfig, args: &Args) -> Result<()> {
     let data = {
         let mut d = app_config
             .favorites
@@ -18,7 +18,7 @@ pub(crate) fn list_favorites(app_config: &AppConfig, args: &Args) -> Result<()> 
                     .collect::<Vec<(&String, &FavoriteConfig)>>()
             })
             .unwrap_or_default();
-        d.sort_by_key(|(key, _)| key.to_string());
+        d.sort_by_key(|(key, _)| (*key).to_string());
         d
     };
 
@@ -48,7 +48,7 @@ pub(crate) fn list_favorites(app_config: &AppConfig, args: &Args) -> Result<()> 
     Ok(())
 }
 
-pub(crate) fn resolve_favorite_args_and_default_values(
+pub fn resolve_favorite_args_and_default_values(
     app_config: &AppConfig,
     args: &mut Args,
 ) -> Result<Option<HashMap<String, toml::Value>>> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -24,7 +24,7 @@ enum RepoKind {
     Invalid,
 }
 
-pub(crate) struct GitConfig<'a> {
+pub struct GitConfig<'a> {
     remote: Cow<'a, str>,
     branch: GitReference,
     kind: RepoKind,
@@ -79,7 +79,7 @@ impl<'a> GitConfig<'a> {
     }
 }
 
-pub(crate) fn create(project_dir: &Path, args: GitConfig) -> Result<String> {
+pub fn create(project_dir: &Path, args: GitConfig) -> Result<String> {
     let branch = git_clone_all(project_dir, args)?;
     remove_history(project_dir, None)?;
 
@@ -255,7 +255,7 @@ fn remove_history(project_dir: &Path, attempt: Option<u8>) -> Result<()> {
                     warn!("cargo-generate was not able to delete the git history after {} retries. Please delete the `.git` sub-folder manually", attempt);
                     return Ok(());
                 }
-                let wait_for = Duration::from_secs(2_u64.pow(attempt.sub(1) as u32));
+                let wait_for = Duration::from_secs(2_u64.pow(attempt.sub(1).into()));
                 warn!("Git history cleanup failed with a windows process blocking error. [Retry in {:?}]", wait_for);
                 sleep(wait_for);
                 remove_history(project_dir, Some(attempt.add(1)))?

--- a/src/ignore_me.rs
+++ b/src/ignore_me.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::config::CONFIG_FILE_NAME;
-pub(crate) const IGNORE_FILE_NAME: &str = ".genignore";
+pub const IGNORE_FILE_NAME: &str = ".genignore";
 
 // We ignore the `.cargo-ok` file if one is present. This file is a somewhat
 // obscure marker that cargo leaves around after extracting a tarball to
@@ -22,7 +22,7 @@ const CARGO_OK_FILE_NAME: &str = ".cargo-ok";
 /// Takes the directory path and removes the files/directories specified in the
 /// `.genignore` file
 /// It handles all errors internally
-pub(crate) fn remove_unneeded_files(dir: &Path, verbose: bool) {
+pub fn remove_unneeded_files(dir: &Path, verbose: bool) {
     let items = get_ignored(dir);
     remove_dir_files(items, verbose);
 }

--- a/src/include_exclude.rs
+++ b/src/include_exclude.rs
@@ -4,7 +4,7 @@ use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use std::path::Path;
 
 #[derive(Default)]
-pub(crate) struct Matcher(Option<MatcherKind>);
+pub struct Matcher(Option<MatcherKind>);
 
 enum MatcherKind {
     Include(Gitignore),
@@ -12,7 +12,7 @@ enum MatcherKind {
 }
 
 impl Matcher {
-    pub(crate) fn new(template_config: TemplateConfig, project_dir: &Path) -> Result<Self> {
+    pub fn new(template_config: TemplateConfig, project_dir: &Path) -> Result<Self> {
         let kind = match (&template_config.exclude, &template_config.include) {
             (None, None) => None,
             (None, Some(it)) => Some(MatcherKind::Include(Self::create_matcher(project_dir, it)?)),
@@ -33,7 +33,7 @@ impl Matcher {
         Ok(builder.build()?)
     }
 
-    pub(crate) fn should_include(&self, relative_path: &Path) -> bool {
+    pub fn should_include(&self, relative_path: &Path) -> bool {
         // "Include" and "exclude" options are mutually exclusive.
         // if no include is made, we will default to ignore_exclude
         // which if there is no options, matches everything

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,28 @@
 //!
 //! `os-arch` and `authors` also can't be overriden and are derived from the environment.
 
-#![warn(clippy::unneeded_field_pattern, clippy::match_bool, clippy::get_unwrap)]
+#![warn(
+    //clippy::cargo_common_metadata,
+    clippy::branches_sharing_code,
+    clippy::cast_lossless,
+    clippy::cognitive_complexity,
+    clippy::get_unwrap,
+    clippy::if_then_some_else_none,
+    clippy::inefficient_to_string,
+    clippy::match_bool,
+    clippy::missing_const_for_fn,
+    clippy::missing_panics_doc,
+    clippy::option_if_let_else,
+    clippy::redundant_closure,
+    clippy::redundant_else,
+    clippy::redundant_pub_crate,
+    clippy::ref_binding_to_reference,
+    clippy::ref_option_ref,
+    clippy::same_functions_in_if_condition,
+    clippy::unneeded_field_pattern,
+    clippy::unnested_or_patterns,
+    clippy::use_self,
+)]
 
 mod app_config;
 mod args;

--- a/src/progressbar.rs
+++ b/src/progressbar.rs
@@ -1,10 +1,10 @@
 use indicatif::{MultiProgress, ProgressStyle};
 
-pub(crate) fn new() -> MultiProgress {
+pub fn new() -> MultiProgress {
     MultiProgress::new()
 }
 
-pub(crate) fn spinner() -> ProgressStyle {
+pub fn spinner() -> ProgressStyle {
     ProgressStyle::default_spinner()
         .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ ")
         .template("{prefix:.bold.dim} {spinner} {wide_msg}")

--- a/src/project_variables.rs
+++ b/src/project_variables.rs
@@ -8,20 +8,20 @@ use thiserror::Error;
 use crate::config::{Config, TemplateSlotsTable};
 
 #[derive(Debug)]
-pub(crate) struct TemplateSlots {
+pub struct TemplateSlots {
     pub(crate) var_name: String,
     pub(crate) var_info: VarInfo,
     pub(crate) prompt: String,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum VarInfo {
+pub enum VarInfo {
     Bool { default: Option<bool> },
     String { entry: Box<StringEntry> },
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct StringEntry {
+pub struct StringEntry {
     pub(crate) default: Option<String>,
     pub(crate) choices: Option<Vec<String>>,
     pub(crate) regex: Option<Regex>,
@@ -85,7 +85,7 @@ const RESERVED_NAMES: [&str; 5] = [
     "crate_type",
 ];
 
-pub(crate) fn fill_project_variables<F>(
+pub fn fill_project_variables<F>(
     mut template_object: Object,
     template_config: &Config,
     silent: bool,

--- a/src/template.rs
+++ b/src/template.rs
@@ -33,7 +33,7 @@ fn engine() -> liquid::Parser {
     description = "Change text to kebab-case.",
     parsed(KebabCaseFilter)
 )]
-pub(crate) struct KebabCaseFilterParser;
+pub struct KebabCaseFilterParser;
 
 #[derive(Debug, Default, liquid_derive::Display_filter)]
 #[name = "kebab_case"]
@@ -60,7 +60,7 @@ impl Filter for KebabCaseFilter {
     description = "Change text to PascalCase.",
     parsed(PascalCaseFilter)
 )]
-pub(crate) struct PascalCaseFilterParser;
+pub struct PascalCaseFilterParser;
 
 #[derive(Debug, Default, liquid_derive::Display_filter)]
 #[name = "pascal_case"]
@@ -87,7 +87,7 @@ impl Filter for PascalCaseFilter {
     description = "Change text to snake_case.",
     parsed(SnakeCaseFilter)
 )]
-pub(crate) struct SnakeCaseFilterParser;
+pub struct SnakeCaseFilterParser;
 
 #[derive(Debug, Default, liquid_derive::Display_filter)]
 #[name = "snake_case"]
@@ -108,7 +108,7 @@ impl Filter for SnakeCaseFilter {
     }
 }
 
-pub(crate) fn substitute(
+pub fn substitute(
     name: &ProjectName,
     crate_type: &CrateType,
     template_values: &HashMap<String, toml::Value>,
@@ -147,7 +147,7 @@ pub(crate) fn substitute(
     Ok(liquid_object)
 }
 
-pub(crate) fn walk_dir(
+pub fn walk_dir(
     project_dir: &Path,
     template: Object,
     template_config: Option<TemplateConfig>,

--- a/src/template_variables/authors.rs
+++ b/src/template_variables/authors.rs
@@ -2,12 +2,12 @@ use anyhow::Result;
 use git2::{Config as GitConfig, Repository as GitRepository};
 use std::env;
 
-pub(crate) type Authors = String;
+pub type Authors = String;
 
 /// Taken from cargo and thus (c) 2020 Cargo Developers
 ///
 /// cf. <https://github.com/rust-lang/cargo/blob/2d5c2381e4e50484bf281fc1bfe19743aa9eb37a/src/cargo/ops/cargo_new.rs#L769-L851>
-pub(crate) fn get_authors() -> Result<Authors> {
+pub fn get_authors() -> Result<Authors> {
     fn get_environment_variable(variables: &[&str]) -> Option<String> {
         variables.iter().filter_map(|var| env::var(var).ok()).next()
     }

--- a/src/template_variables/crate_type.rs
+++ b/src/template_variables/crate_type.rs
@@ -1,13 +1,13 @@
 use crate::Args;
 
-pub(crate) type CrateType = cargo::core::compiler::CrateType;
+pub type CrateType = cargo::core::compiler::CrateType;
 
 impl From<&Args> for CrateType {
-    fn from(a: &Args) -> CrateType {
+    fn from(a: &Args) -> Self {
         if a.lib {
-            CrateType::Lib
+            Self::Lib
         } else {
-            CrateType::Bin
+            Self::Bin
         }
     }
 }

--- a/src/template_variables/mod.rs
+++ b/src/template_variables/mod.rs
@@ -11,12 +11,12 @@ use regex::Regex;
 use std::{collections::HashMap, fmt::Display, fs, path::Path};
 use toml::Value;
 
-pub(crate) use authors::{get_authors, Authors};
-pub(crate) use crate_type::CrateType;
-pub(crate) use os_arch::get_os_arch;
-pub(crate) use project_name::ProjectName;
+pub use authors::{get_authors, Authors};
+pub use crate_type::CrateType;
+pub use os_arch::get_os_arch;
+pub use project_name::ProjectName;
 
-pub(crate) fn resolve_template_values(
+pub fn resolve_template_values(
     favorite_values: Option<HashMap<String, toml::Value>>,
     args: &Args,
 ) -> Result<HashMap<String, Value>> {

--- a/src/template_variables/os_arch.rs
+++ b/src/template_variables/os_arch.rs
@@ -1,7 +1,7 @@
 use std::env;
 
-pub(crate) type OsArch = String;
+pub type OsArch = String;
 
-pub(crate) fn get_os_arch() -> OsArch {
+pub fn get_os_arch() -> OsArch {
     format!("{}-{}", env::consts::OS, env::consts::ARCH)
 }

--- a/src/template_variables/project_name.rs
+++ b/src/template_variables/project_name.rs
@@ -2,13 +2,13 @@ use heck::{KebabCase, SnakeCase};
 
 /// Stores user inputted name and provides convenience methods
 /// for handling casing.
-pub(crate) struct ProjectName {
+pub struct ProjectName {
     pub(crate) user_input: String,
 }
 
 impl ProjectName {
-    pub(crate) fn new(name: impl Into<String>) -> ProjectName {
-        ProjectName {
+    pub(crate) fn new(name: impl Into<String>) -> Self {
+        Self {
             user_input: name.into(),
         }
     }


### PR DESCRIPTION
Went through the list of clippy warnings and added some that makes sense - such as using `pub(crate)` in private modules.
