### PR TITLE
feat: prompt for subfolder upon multiple templates

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use std::path::Path;
 use std::{collections::HashMap, fs};
 use std::{convert::TryFrom, io::ErrorKind};
+use walkdir::WalkDir;
 
 pub const CONFIG_FILE_NAME: &str = "cargo-generate.toml";
 
@@ -60,6 +61,27 @@ impl Config {
             None => Ok(None),
         }
     }
+}
+
+pub fn locate_template_configs(dir: &Path) -> Result<Vec<String>> {
+    let mut result = vec![];
+
+    for entry in WalkDir::new(dir) {
+        let entry = entry?;
+        if entry.file_name() == CONFIG_FILE_NAME {
+            let path = entry
+                .path()
+                .parent()
+                .unwrap()
+                .strip_prefix(dir)
+                .unwrap()
+                .to_string_lossy()
+                .to_string();
+            result.push(path)
+        }
+    }
+
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -86,7 +86,7 @@ pub fn locate_template_configs(dir: &Path) -> Result<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::create_file;
+    use crate::tests::{create_file, PathString};
 
     use super::*;
     use std::fs::File;
@@ -116,8 +116,10 @@ mod tests {
         create_file(&tmp, "dir3/Cargo.toml", "")?;
         create_file(&tmp, "dir4/cargo-generate.toml", "")?;
 
-        let separator = std::path::MAIN_SEPARATOR.to_string();
-        let expected = vec!["dir2/dir2_2".replace("/", &separator), "dir4".to_string()];
+        let expected = vec![
+            Path::new("dir2").join("dir2_2").to_string(),
+            "dir4".to_string(),
+        ];
         let result = {
             let mut x = locate_template_configs(tmp.path())?;
             x.sort();

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -49,7 +49,7 @@ fn extract_default(variable: &VarInfo) -> Option<String> {
     }
 }
 
-fn prompt_for_variable(variable: &TemplateSlots) -> Result<String> {
+pub fn prompt_for_variable(variable: &TemplateSlots) -> Result<String> {
     let prompt = format!("{} {}", emoji::SHRUG, style(&variable.prompt).bold(),);
 
     if let VarInfo::String { entry } = &variable.var_info {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,8 @@ fn prepare_local_template(args: &Args) -> Result<(TempDir, PathBuf, String), any
         (None, Some(_)) => {
             let template_base_dir = copy_path_template_into_temp(args)?;
             let branch = args.branch.clone().unwrap_or_else(|| String::from("main"));
-            let template_folder = auto_locate_template_dir(template_base_dir.path())?;
+            let template_folder =
+                auto_locate_template_dir(template_base_dir.path(), prompt_for_variable)?;
             (template_base_dir, template_folder, branch)
         }
         _ => bail!(
@@ -219,13 +220,19 @@ fn resolve_template_dir(template_base_dir: &TempDir, args: &Args) -> Result<Path
                 ));
             }
 
-            Ok(auto_locate_template_dir(&template_dir)?)
+            Ok(auto_locate_template_dir(
+                &template_dir,
+                prompt_for_variable,
+            )?)
         }
-        None => auto_locate_template_dir(template_base_dir.path()),
+        None => auto_locate_template_dir(template_base_dir.path(), prompt_for_variable),
     }
 }
 
-fn auto_locate_template_dir(template_base_dir: &Path) -> Result<PathBuf> {
+fn auto_locate_template_dir(
+    template_base_dir: &Path,
+    prompt: impl Fn(&TemplateSlots) -> Result<String>,
+) -> Result<PathBuf> {
     let config_paths = locate_template_configs(template_base_dir)?;
     match config_paths.len() {
         0 => Ok(template_base_dir.to_owned()),
@@ -242,7 +249,7 @@ fn auto_locate_template_dir(template_base_dir: &Path) -> Result<PathBuf> {
                     }),
                 },
             };
-            let path = prompt_for_variable(&prompt_args)?;
+            let path = prompt(&prompt_args)?;
             Ok(template_base_dir.join(&path))
         }
     }
@@ -537,5 +544,77 @@ fn rename_warning(name: &ProjectName) {
             style(&name.kebab_case()).bold().green(),
             style("...").bold()
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{auto_locate_template_dir, project_variables::VarInfo};
+    use anyhow::anyhow;
+    use std::{fs, io::Write};
+    use tempfile::{tempdir, TempDir};
+
+    #[test]
+    fn auto_locate_template_returns_base_when_no_cargo_generate_is_found() -> anyhow::Result<()> {
+        let tmp = tempdir().unwrap();
+        create_file(&tmp, "dir1/Cargo.toml", "")?;
+        create_file(&tmp, "dir2/dir2_1/Cargo.toml", "")?;
+        create_file(&tmp, "dir3/Cargo.toml", "")?;
+
+        let r = auto_locate_template_dir(tmp.path(), |_slots| Err(anyhow!("test")))?;
+        assert_eq!(tmp.path(), r);
+        Ok(())
+    }
+
+    #[test]
+    fn auto_locate_template_returns_path_when_single_cargo_generate_is_found() -> anyhow::Result<()>
+    {
+        let tmp = tempdir().unwrap();
+        create_file(&tmp, "dir1/Cargo.toml", "")?;
+        create_file(&tmp, "dir2/dir2_1/Cargo.toml", "")?;
+        create_file(&tmp, "dir2/dir2_2/cargo-generate.toml", "")?;
+        create_file(&tmp, "dir3/Cargo.toml", "")?;
+
+        let r = auto_locate_template_dir(tmp.path(), |_slots| Err(anyhow!("test")))?;
+        assert_eq!(tmp.path().join("dir2/dir2_2"), r);
+        Ok(())
+    }
+
+    #[test]
+    fn auto_locate_template_prompts_when_multiple_cargo_generate_is_found() -> anyhow::Result<()> {
+        let tmp = tempdir().unwrap();
+        create_file(&tmp, "dir1/Cargo.toml", "")?;
+        create_file(&tmp, "dir2/dir2_1/Cargo.toml", "")?;
+        create_file(&tmp, "dir2/dir2_2/cargo-generate.toml", "")?;
+        create_file(&tmp, "dir3/Cargo.toml", "")?;
+        create_file(&tmp, "dir4/cargo-generate.toml", "")?;
+
+        let r = auto_locate_template_dir(tmp.path(), |slots| match &slots.var_info {
+            VarInfo::Bool { .. } => anyhow::bail!("Wrong prompt type"),
+            VarInfo::String { entry } => {
+                if let Some(mut choices) = entry.choices.clone() {
+                    choices.sort();
+                    let separator = std::path::MAIN_SEPARATOR.to_string();
+                    let expected = vec!["dir2/dir2_2".replace("/", &separator), "dir4".to_string()];
+                    assert_eq!(expected, choices);
+                    Ok("my_path".to_string())
+                } else {
+                    anyhow::bail!("Missing choices")
+                }
+            }
+        });
+        assert_eq!(tmp.path().join("my_path"), r?);
+
+        Ok(())
+    }
+
+    pub fn create_file(base_path: &TempDir, path: &str, contents: &str) -> anyhow::Result<()> {
+        let path = base_path.path().join(path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        fs::File::create(&path)?.write_all(contents.as_ref())?;
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,7 +551,11 @@ fn rename_warning(name: &ProjectName) {
 mod tests {
     use crate::{auto_locate_template_dir, project_variables::VarInfo};
     use anyhow::anyhow;
-    use std::{fs, io::Write};
+    use std::{
+        fs,
+        io::Write,
+        path::{Path, PathBuf},
+    };
     use tempfile::{tempdir, TempDir};
 
     #[test]
@@ -594,8 +598,10 @@ mod tests {
             VarInfo::String { entry } => {
                 if let Some(mut choices) = entry.choices.clone() {
                     choices.sort();
-                    let separator = std::path::MAIN_SEPARATOR.to_string();
-                    let expected = vec!["dir2/dir2_2".replace("/", &separator), "dir4".to_string()];
+                    let expected = vec![
+                        Path::new("dir2").join("dir2_2").to_string(),
+                        "dir4".to_string(),
+                    ];
                     assert_eq!(expected, choices);
                     Ok("my_path".to_string())
                 } else {
@@ -606,6 +612,22 @@ mod tests {
         assert_eq!(tmp.path().join("my_path"), r?);
 
         Ok(())
+    }
+
+    pub trait PathString {
+        fn to_string(&self) -> String;
+    }
+
+    impl PathString for PathBuf {
+        fn to_string(&self) -> String {
+            self.as_path().to_string()
+        }
+    }
+
+    impl PathString for Path {
+        fn to_string(&self) -> String {
+            self.display().to_string()
+        }
     }
 
     pub fn create_file(base_path: &TempDir, path: &str, contents: &str) -> anyhow::Result<()> {


### PR DESCRIPTION
This lets the user specify the base path (or git repo) for a potential multi-template repo. If there's more than 1 template in the repo, the user is asked to select the one to expand.

Given the user specifies a template folder without `cargo-generate.toml`, look for the config in child dirs. Then depending upon the number of configs found do:

0 => use the user specified folder
1 => use the folder with the found config
2+ => prompt the user for which template to use.

![t-rec_1](https://user-images.githubusercontent.com/7338549/132187949-befdcaf3-a9ba-426b-b530-e4d6046a8c3d.gif)
