### PR TITLE
Save 33% in size on release binary, bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "anymap2"
@@ -45,9 +45,9 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f002ce7d0c5e809ebb02be78fd503aeed4a511fd0fcaff6e6914cbdabbfa33"
+checksum = "b800c4403e8105d959595e1f88119e78bc12bc874c4336973658b648a746ba93"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.21"
+version = "0.13.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490"
+checksum = "9c1cbbfc9a1996c6af82c2b4caf828d2c653af4fcdbb0e5674cc966eee5a4197"
 dependencies = [
  "bitflags",
  "libc",
@@ -547,9 +547,9 @@ checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.22+1.1.0"
+version = "0.12.23+1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3"
+checksum = "29730a445bae719db3107078b46808cc45a5b7a6bae3f31272923af969453356"
 dependencies = [
  "cc",
  "libc",
@@ -1069,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a96634536a35f7bd2a8e6c35fdc684c719e8a3a1fef26ff17ade63509793f40"
+checksum = "ffe77a5cb19d8925c19c4f93fe002801eb3697cf19f714ae230364ef3518310a"
 dependencies = [
  "ahash",
  "instant",
@@ -1255,18 +1255,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,6 @@ vendored-openssl = ['openssl/vendored']
 [[bin]]
 path = "src/main.rs"
 name = "cargo-generate"
+
+[profile.release]
+lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ console = "0.14.1"
 dialoguer = "0.8.0"
 dirs = "3.0.2"
 indicatif = "0.16.2"
-git2 = "0.13.21"
+git2 = "0.13.22"
 tempfile = "3.2.0"
 regex = "1.5.4"
 heck = "0.3.3"
@@ -27,13 +27,13 @@ walkdir = "2.3.2"
 remove_dir_all = "0.7.0"
 ignore = "0.4.18"
 url = "2.2.2"
-structopt = "0.3.22"
-anyhow = "1.0.43"
+structopt = "0.3.23"
+anyhow = "1.0.44"
 toml = "0.5.8"
-thiserror = "1.0.28"
+thiserror = "1.0.29"
 home = "0.5.3"
 sanitize-filename = "0.3"
-rhai = "1.0.2"
+rhai = "1.0.4"
 
 [dependencies.openssl]
 version = "0.10.36"
@@ -44,12 +44,12 @@ version = "1.0.4"
 features = ["serde"]
 
 [dependencies.serde]
-version = "1.0.125"
+version = "1.0.130"
 features = ["derive"]
 
 [dev-dependencies]
 predicates = "2.0.2"
-assert_cmd = "2.0.0"
+assert_cmd = "2.0.1"
 indoc = "1.0.3"
 
 [features]


### PR DESCRIPTION
closes #453
closes #452
closes #451
closes #449
closes #448