### PR TITLE
maintenance: whitelist `time` advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,7 @@
+# See https://github.com/rustsec/rustsec/blob/59e1d2ad0b9cbc6892c26de233d4925074b4b97b/cargo-audit/audit.toml.example for example.
+
+[advisories]
+ignore = [
+    "RUSTSEC-2020-0071",
+    "RUSTSEC-2020-0159",
+]


### PR DESCRIPTION
This will fix the `audit` step that is failing in CI.

The same file is used in [tokio](https://github.com/tokio-rs/tokio/blob/master/.cargo/audit.toml)