### PR TITLE
README: fix example regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ until the user entered something that is allowed by this regex.
 An example with a regex that allows only numbers
 ```toml
 [placeholders]
-phone_number = { type = "string", prompt = "What's your phone number?", regex = "[0-9]+" }
+phone_number = { type = "string", prompt = "What's your phone number?", regex = "^[0-9]+$" }
 ```
 
 ## Default values for placeholders


### PR DESCRIPTION
In this way strings that start or end with a letter are not matched.
Otherwise strings like `a22` or `321b` are recognized as `phone_number`.