### PR TITLE
fix(#510): Using `--path` bring the `.git` folder from the source with it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e996dc7940838b7ef1096b882e29ec30a3149a3a443cdc8dba19ed382eca1fe2"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
@@ -874,9 +874,9 @@ checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "predicates"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e5a7689e456ab905c22c2b48225bb921aba7c8dfa58440d68ba13f6222a715"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -888,15 +888,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -1065,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00a731f4b606602a1683ae0a1289a59497c39075fb6dc56ce9ec9251ef48b89"
+checksum = "2c7433068977c56619bf2b7831da26eb986d0645fe56f2ad9357eda7ae4c435e"
 dependencies = [
  "ahash",
  "instant",
@@ -1079,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "rhai_codegen"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14fd9df9de7895cb7e79ba593a9d8eb00a769178476480c26703b97b500a726"
+checksum = "e02d33d76a7aa8ec72ac8298d5b52134fd2dff77445ada0c65f6f8c40d8f2931"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1207,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1242,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"

--- a/src/git.rs
+++ b/src/git.rs
@@ -259,7 +259,7 @@ fn git_clone_all(project_dir: &Path, args: GitConfig) -> Result<String> {
     }
 }
 
-fn remove_history(project_dir: &Path, attempt: Option<u8>) -> Result<()> {
+pub fn remove_history(project_dir: &Path, attempt: Option<u8>) -> Result<()> {
     let git_dir = project_dir.join(".git");
     if git_dir.exists() && git_dir.is_dir() {
         if let Err(e) = remove_dir_all(git_dir) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,8 @@ fn copy_path_template_into_temp(args: &Args) -> Result<TempDir> {
             .with_context(|| "Missing option git, path or a favorite")?,
         path_clone_dir.path(),
     )?;
+    git::remove_history(path_clone_dir.path(), None)?;
+
     Ok(path_clone_dir)
 }
 

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -102,7 +102,7 @@ version = "0.1.0"
 
     let target_path = dir.target_path("foobar-project");
     let repo = git2::Repository::open(&target_path).unwrap();
-    assert!(repo.is_empty().unwrap());
+    assert_eq!(0, repo.references().unwrap().count());
 }
 
 #[test]
@@ -134,7 +134,7 @@ version = "0.1.0"
 
     let target_path = dir.target_path("xyz");
     let repo = git2::Repository::open(&target_path).unwrap();
-    assert!(repo.is_empty().unwrap());
+    assert_eq!(0, repo.references().unwrap().count());
 }
 
 #[test]

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -100,9 +100,41 @@ version = "0.1.0"
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
 
-    let repo = git2::Repository::open(&dir.path().join("foobar-project")).unwrap();
-    let references = repo.references().unwrap().count();
-    assert_eq!(0, references);
+    let target_path = dir.target_path("foobar-project");
+    let repo = git2::Repository::open(&target_path).unwrap();
+    assert!(repo.is_empty().unwrap());
+}
+
+#[test]
+fn it_removes_git_history_also_on_local_templates() {
+    let template = tmp_dir()
+        .file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .init_git()
+        .build();
+
+    let dir = tmp_dir().build();
+
+    binary()
+        .arg("generate")
+        .arg("--path")
+        .arg(template.path())
+        .arg("--name")
+        .arg("xyz")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    let target_path = dir.target_path("xyz");
+    let repo = git2::Repository::open(&target_path).unwrap();
+    assert!(repo.is_empty().unwrap());
 }
 
 #[test]

--- a/tests/integration/helpers/project.rs
+++ b/tests/integration/helpers/project.rs
@@ -1,7 +1,7 @@
 use assert_cmd::prelude::*;
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
 
@@ -30,6 +30,11 @@ impl Project {
 
     pub fn path(&self) -> &Path {
         self.root.path()
+    }
+
+    /// returns the path of the generated project aka target path
+    pub fn target_path(&self, name: impl AsRef<str>) -> PathBuf {
+        self.path().join(name.as_ref())
     }
 
     pub fn exists(&self, path: &str) -> bool {


### PR DESCRIPTION
- now also for local folders e.g. via `--path` the `.git` repo is fresh and clean initialized as expected
- test case is added
- other test case is refined
- this fixes #510 