### PR TITLE
feat(#516): implement force git init flag

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -7,7 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::emoji;
+use crate::info;
 
 pub const CONFIG_FILE_NAME: &str = "cargo-generate.toml";
 
@@ -34,9 +34,8 @@ impl AppConfig {
             Ok(if cfg.trim().is_empty() {
                 Self::default()
             } else {
-                println!(
-                    "{} {} {}",
-                    emoji::INFO,
+                info!(
+                    "{} {}",
                     style("Using application config:").bold(),
                     style(path.display()).underlined()
                 );

--- a/src/args.rs
+++ b/src/args.rs
@@ -146,13 +146,10 @@ impl FromStr for Vcs {
 }
 
 impl Vcs {
-    pub fn initialize(&self, project_dir: &Path, branch: String) -> Result<()> {
+    pub fn initialize(&self, project_dir: &Path, branch: String, force: bool) -> Result<()> {
         match self {
-            Self::None => {}
-            Self::Git => {
-                git::init(project_dir, &branch)?;
-            }
-        };
-        Ok(())
+            Self::None => Ok(()),
+            Self::Git => git::init(project_dir, &branch, force).map(|_| ()),
+        }
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -121,6 +121,10 @@ pub struct Args {
     /// Generate the template directly into the current dir. No subfolder will be created and no vcs is initialized.
     #[structopt(long)]
     pub init: bool,
+
+    /// Will enforce a fresh git init on the generated project
+    #[structopt(long)]
+    pub force_git_init: bool,
 }
 
 #[derive(Debug, StructOpt, Clone, Copy)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -301,13 +301,24 @@ pub fn remove_history(project_dir: &Path, attempt: Option<u8>) -> Result<()> {
     Ok(())
 }
 
-pub fn init(project_dir: &Path, branch: &str) -> Result<Repository> {
-    Repository::discover(project_dir).or_else(|_| {
+pub fn init(project_dir: &Path, branch: &str, force: bool) -> Result<Repository> {
+    fn just_init(project_dir: &Path, branch: &str) -> Result<Repository> {
         let mut opts = RepositoryInitOptions::new();
         opts.bare(false);
         opts.initial_head(branch);
         Repository::init_opts(project_dir, &opts).context("Couldn't init new repository")
-    })
+    }
+
+    match Repository::discover(project_dir) {
+        Ok(repo) => {
+            if force {
+                Repository::open(project_dir).or_else(|_| just_init(project_dir, branch))
+            } else {
+                Ok(repo)
+            }
+        }
+        Err(_) => just_init(project_dir, branch),
+    }
 }
 
 /// determines what kind of repository we got

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,8 +115,10 @@ pub fn generate(mut args: Args) -> Result<()> {
     );
     copy_dir_all(&template_folder, &project_dir)?;
 
-    if !args.init {
-        args.vcs.initialize(&project_dir, branch)?;
+    if !args.init || args.force_git_init {
+        info!("{}", style("Initializing a fresh Git repository").bold());
+        args.vcs
+            .initialize(&project_dir, branch, args.force_git_init)?;
     }
 
     println!(

--- a/src/log.rs
+++ b/src/log.rs
@@ -7,3 +7,13 @@ macro_rules! warn {
         );
     })
 }
+
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => ({
+        println!("{} {}",
+            $crate::emoji::INFO,
+            format!($($arg)*)
+        );
+    })
+}

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -74,70 +74,6 @@ version = "0.1.0"
 }
 
 #[test]
-fn it_removes_git_history() {
-    let template = tmp_dir()
-        .file(
-            "Cargo.toml",
-            r#"[package]
-name = "{{project-name}}"
-description = "A wonderful project"
-version = "0.1.0"
-"#,
-        )
-        .init_git()
-        .build();
-
-    let dir = tmp_dir().build();
-
-    binary()
-        .arg("generate")
-        .arg("--git")
-        .arg(template.path())
-        .arg("--name")
-        .arg("foobar-project")
-        .current_dir(&dir.path())
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("Done!").from_utf8());
-
-    let target_path = dir.target_path("foobar-project");
-    let repo = git2::Repository::open(&target_path).unwrap();
-    assert_eq!(0, repo.references().unwrap().count());
-}
-
-#[test]
-fn it_removes_git_history_also_on_local_templates() {
-    let template = tmp_dir()
-        .file(
-            "Cargo.toml",
-            r#"[package]
-name = "{{project-name}}"
-description = "A wonderful project"
-version = "0.1.0"
-"#,
-        )
-        .init_git()
-        .build();
-
-    let dir = tmp_dir().build();
-
-    binary()
-        .arg("generate")
-        .arg("--path")
-        .arg(template.path())
-        .arg("--name")
-        .arg("xyz")
-        .current_dir(&dir.path())
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("Done!").from_utf8());
-
-    let target_path = dir.target_path("xyz");
-    let repo = git2::Repository::open(&target_path).unwrap();
-    assert_eq!(0, repo.references().unwrap().count());
-}
-
-#[test]
 fn it_substitutes_projectname_in_cargo_toml() {
     let template = tmp_dir()
         .file(
@@ -796,42 +732,6 @@ version = "0.1.0"
     )
     .unwrap()
     .is_file());
-}
-
-#[test]
-fn it_allows_a_git_branch_to_be_specified() {
-    // Build and commit on branch named 'main'
-    let template = tmp_dir()
-        .file(
-            "Cargo.toml",
-            r#"[package]
-name = "{{project-name}}"
-description = "A wonderful project"
-version = "0.1.0"
-"#,
-        )
-        .init_git()
-        .branch("baz")
-        .build();
-
-    let dir = tmp_dir().build();
-
-    binary()
-        .arg("generate")
-        .arg("--branch")
-        .arg("baz")
-        .arg("--git")
-        .arg(template.path())
-        .arg("--name")
-        .arg("foobar-project")
-        .current_dir(&dir.path())
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("Done!").from_utf8());
-
-    assert!(dir
-        .read("foobar-project/Cargo.toml")
-        .contains("foobar-project"));
 }
 
 #[test]

--- a/tests/integration/git.rs
+++ b/tests/integration/git.rs
@@ -1,0 +1,71 @@
+use assert_cmd::prelude::*;
+use git2::Repository;
+use predicates::prelude::*;
+
+use crate::helpers::project::binary;
+use crate::helpers::project_builder::tmp_dir;
+
+#[test]
+fn it_allows_a_git_branch_to_be_specified() {
+    let template = tmp_dir().init_default_template().branch("bak").build();
+    let dir = tmp_dir().build();
+
+    binary()
+        .arg("generate")
+        .arg("--branch")
+        .arg("bak")
+        .arg("--git")
+        .arg(template.path())
+        .arg("--name")
+        .arg("foobar-project")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(dir
+        .read("foobar-project/Cargo.toml")
+        .contains("foobar-project"));
+}
+
+#[test]
+fn it_removes_git_history() {
+    let template = tmp_dir().init_default_template().build();
+    let dir = tmp_dir().build();
+
+    binary()
+        .arg("generate")
+        .arg("--git")
+        .arg(template.path())
+        .arg("--name")
+        .arg("foobar-project")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    let repo = Repository::open(&dir.path().join("foobar-project")).unwrap();
+    let references = repo.references().unwrap().count();
+    assert_eq!(0, references);
+}
+
+#[test]
+fn it_removes_git_history_also_on_local_templates() {
+    let template = tmp_dir().init_default_template().build();
+    let dir = tmp_dir().build();
+
+    binary()
+        .arg("generate")
+        .arg("--path")
+        .arg(template.path())
+        .arg("--name")
+        .arg("xyz")
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    let target_path = dir.target_path("xyz");
+    let repo = git2::Repository::open(&target_path).unwrap();
+    assert_eq!(0, repo.references().unwrap().count());
+}

--- a/tests/integration/git.rs
+++ b/tests/integration/git.rs
@@ -69,3 +69,25 @@ fn it_removes_git_history_also_on_local_templates() {
     let repo = git2::Repository::open(&target_path).unwrap();
     assert_eq!(0, repo.references().unwrap().count());
 }
+
+#[test]
+fn it_should_init_an_empty_git_repo_even_when_starting_from_a_repo_when_forced() {
+    let template = tmp_dir().init_default_template().build();
+    let target_path = template.path();
+
+    binary()
+        .arg("generate")
+        .arg("--force-git-init")
+        .arg("--git")
+        .arg(template.path())
+        .arg("--name")
+        .arg("foo")
+        .current_dir(&target_path)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    let repo = Repository::open(&target_path.join("foo")).unwrap();
+    let references = repo.references().unwrap().count();
+    assert_eq!(0, references);
+}

--- a/tests/integration/helpers/project_builder.rs
+++ b/tests/integration/helpers/project_builder.rs
@@ -24,22 +24,37 @@ pub fn tmp_dir() -> ProjectBuilder {
 }
 
 impl ProjectBuilder {
-    pub fn file(mut self, name: &str, contents: &str) -> ProjectBuilder {
+    /// builds a template with
+    /// - one file `Cargo.toml` in it
+    /// - one placeholder `project-name`
+    pub fn init_default_template(self) -> Self {
+        self.file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .init_git()
+    }
+
+    pub fn file(mut self, name: &str, contents: &str) -> Self {
         self.files.push((name.to_string(), contents.to_string()));
         self
     }
 
-    pub fn init_git(mut self) -> ProjectBuilder {
+    pub fn init_git(mut self) -> Self {
         self.git = true;
         self
     }
 
-    pub fn branch(mut self, branch: &str) -> ProjectBuilder {
+    pub fn branch(mut self, branch: &str) -> Self {
         self.branch = Some(branch.to_owned());
         self
     }
 
-    pub fn add_submodule<I: Into<String>>(mut self, destination: I, path: I) -> ProjectBuilder {
+    pub fn add_submodule<I: Into<String>>(mut self, destination: I, path: I) -> Self {
         self.submodules.push((destination.into(), path.into()));
         self
     }

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -36,6 +36,7 @@ version = "0.1.0"
         ssh_identity: None,
         define: vec![],
         init: false,
+        force_git_init: false,
     };
     // need to cd to the dir as we aren't running in the cargo shell.
     assert!(std::env::set_current_dir(&dir.root).is_ok());

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -4,6 +4,7 @@ mod helpers;
 mod basics;
 mod favorites;
 mod filenames;
+mod git;
 mod hooks;
 mod library;
 mod values;


### PR DESCRIPTION
this PR introduces a force git init flag `--force-git-init` to make sure that a fresh git repo is initialise, without the parent repository discovery mechanism. 

In case the target folder has already a git repo, it would not be touched.

It fixes #516 