### PR TITLE
feat(#520): Support Git's https to ssh rewriting configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "anymap2"
@@ -134,6 +134,7 @@ dependencies = [
  "console",
  "dialoguer",
  "dirs",
+ "git-config",
  "git2",
  "heck 0.4.0",
  "home",
@@ -343,9 +344,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -401,13 +402,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "git-config"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f45d2795232532958944079ea0c05948b810cd15c5420a3ba4fed9e34f17a864"
+dependencies = [
+ "dirs",
+ "memchr",
+ "nom",
 ]
 
 [[package]]
@@ -565,9 +577,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libgit2-sys"
@@ -701,6 +713,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+ "version_check",
 ]
 
 [[package]]
@@ -967,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1065,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7433068977c56619bf2b7831da26eb986d0645fe56f2ad9357eda7ae4c435e"
+checksum = "898b114d6cfa18af4593393fdc6c7437118e7e624d97f635fba8c75fd5c06f56"
 dependencies = [
  "ahash",
  "instant",
@@ -1124,18 +1153,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1156,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "smartstring"
@@ -1183,9 +1212,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1207,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1277,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -1458,6 +1487,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ home = "0.5"
 sanitize-filename = "0.3"
 rhai = "1.3"
 path-absolutize = "3.0"
+git-config = "0.1.11"
 
 [dependencies.openssl]
 version = "0.10"

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,0 +1,4 @@
+mod remote;
+mod utils;
+
+pub use utils::{create, init, remove_history, GitConfig};

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -1,0 +1,112 @@
+use anyhow::Result;
+use console::style;
+use core::convert::{AsRef, TryFrom};
+use core::result::Result::Ok;
+use std::borrow::Cow;
+use std::path::PathBuf;
+
+use crate::git::utils::{canonicalize_path, determine_repo_kind, resolve_instead_url, RepoKind};
+use crate::info;
+
+/// url and gitconfig content
+pub struct GitUrlAndConfig<'a>(pub Cow<'a, str>, pub PathBuf);
+
+impl<'a> TryFrom<GitUrlAndConfig<'a>> for GitRemote<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: GitUrlAndConfig<'a>) -> Result<Self, Self::Error> {
+        let r = value.0.as_ref();
+        let url = if let Ok(Some(url)) = resolve_instead_url(r, &value.1) {
+            info!(
+                "Using gitconfig `{}` for {:?} -> {:?}",
+                style("insteadOf").bold(),
+                style(r).bold().yellow(),
+                style(&url).bold().yellow()
+            );
+            url
+        } else {
+            r.to_owned()
+        };
+
+        url.try_into()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GitRemote<'a> {
+    url: Cow<'a, str>,
+    kind: RepoKind,
+}
+
+impl<'a> AsRef<str> for GitRemote<'a> {
+    fn as_ref(&self) -> &str {
+        self.url.as_ref()
+    }
+}
+
+impl<'a> TryFrom<Cow<'a, str>> for GitRemote<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(url: Cow<'a, str>) -> Result<Self, Self::Error> {
+        let url = url.as_ref();
+        let (remote, kind) = match determine_repo_kind(url) {
+            RepoKind::Invalid => anyhow::bail!("Invalid git remote '{}'", url),
+            RepoKind::LocalFolder => {
+                let full_path = canonicalize_path(&url)?;
+                if !full_path.exists() {
+                    anyhow::bail!("The given git remote {:?} does not exist.", url);
+                }
+                (full_path.display().to_string(), RepoKind::LocalFolder)
+            }
+            k => (url.to_string(), k),
+        };
+        Ok(Self {
+            url: Cow::from(remote),
+            kind,
+        })
+    }
+}
+
+impl<'a> TryFrom<String> for GitRemote<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(url: String) -> Result<Self, Self::Error> {
+        Cow::from(url).try_into()
+    }
+}
+
+impl<'a> TryFrom<&'a str> for GitRemote<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(url: &'a str) -> Result<Self, Self::Error> {
+        Cow::from(url).try_into()
+    }
+}
+
+impl<'a> AsRef<RepoKind> for GitRemote<'a> {
+    fn as_ref(&self) -> &RepoKind {
+        &self.kind
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_provide_a_remove() {
+        let sample_config = r#"
+[url "ssh://git@github.com:"]
+    insteadOf = https://github.com/
+"#;
+        let where_gitconfig_lives = tempfile::tempdir().unwrap();
+        let gitconfig = where_gitconfig_lives.path().join(".gitconfig");
+        std::fs::write(&gitconfig, sample_config).unwrap();
+
+        let remote = GitUrlAndConfig(Cow::from("https://github.com/sassman/t-rec-rs"), gitconfig);
+        let remote: GitRemote = remote.try_into().unwrap();
+        let remote: &str = remote.as_ref();
+
+        assert_eq!(remote, "ssh://git@github.com:sassman/t-rec-rs");
+    }
+}

--- a/src/git/utils.rs
+++ b/src/git/utils.rs
@@ -1,12 +1,15 @@
-use crate::copy_dir_all;
-use crate::emoji;
+use crate::git::remote::{GitRemote, GitUrlAndConfig};
 use crate::warn;
+use crate::{copy_dir_all, info};
+
 use anyhow::Context;
 use anyhow::Result;
 use console::style;
 use git2::build::RepoBuilder;
 use git2::{Cred, FetchOptions, ProxyOptions, RemoteCallbacks, Repository, RepositoryInitOptions};
 use git2::{ErrorClass, ErrorCode};
+use git_config::file::GitConfig as GitConfigParser;
+use git_config::parser::Key;
 use remove_dir_all::remove_dir_all;
 use std::borrow::Cow;
 use std::ops::{Add, Sub};
@@ -14,12 +17,13 @@ use std::path::{Path, PathBuf};
 use std::thread::sleep;
 use std::time::Duration;
 
-#[derive(Debug, PartialEq)]
-enum RepoKind {
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RepoKind {
     LocalFolder,
     RemoteHttp,
     RemoteHttps,
     RemoteSsh,
+    RemoteGit,
     Invalid,
 }
 
@@ -33,35 +37,28 @@ pub enum GitReference {
 }
 
 pub struct GitConfig<'a> {
-    remote: Cow<'a, str>,
+    remote: GitRemote<'a>,
     branch: GitReference,
-    kind: RepoKind,
     identity: Option<PathBuf>,
 }
 
 impl<'a> GitConfig<'a> {
     /// Creates a new `GitConfig` by parsing `git` as a URL or a local path.
     pub fn new(
-        git: impl AsRef<str>,
+        git: impl AsRef<str> + 'a,
         branch: Option<String>,
         identity: Option<PathBuf>,
     ) -> Result<Self> {
-        let git = git.as_ref();
-        let (remote, kind) = match determine_repo_kind(git) {
-            RepoKind::Invalid => anyhow::bail!("Invalid git remote '{}'", git),
-            RepoKind::LocalFolder => {
-                let full_path = canonicalize_path(Path::new(git))?;
-                if !full_path.exists() {
-                    anyhow::bail!("The given git remote {:?} does not exist.", git);
-                }
-                (full_path.display().to_string(), RepoKind::LocalFolder)
-            }
-            k => (git.to_string(), k),
+        let git = Cow::from(git.as_ref().to_string());
+        let gitconfig = find_gitconfig()?;
+        let remote = if let Some(gitconfig) = gitconfig {
+            GitRemote::try_from(GitUrlAndConfig(git, gitconfig))?
+        } else {
+            GitRemote::try_from(git)?
         };
 
         Ok(GitConfig {
-            remote: Cow::from(remote),
-            kind,
+            remote,
             identity,
             branch: branch
                 .map(GitReference::Branch)
@@ -86,7 +83,7 @@ impl<'a> GitConfig<'a> {
     }
 }
 
-fn abbreviated_git_url_to_full_remote(git: impl AsRef<str>) -> String {
+pub fn abbreviated_git_url_to_full_remote(git: impl AsRef<str>) -> String {
     let git = git.as_ref();
     if git.len() >= 3 {
         match &git[..3] {
@@ -107,8 +104,9 @@ pub fn create(project_dir: &Path, args: GitConfig) -> Result<String> {
     Ok(branch)
 }
 
-fn canonicalize_path(p: &Path) -> Result<PathBuf> {
-    let p = if p.to_str().unwrap().starts_with("~/") {
+pub fn canonicalize_path(p: impl AsRef<Path>) -> Result<PathBuf> {
+    let p = p.as_ref();
+    let p = if p.starts_with("~/") {
         home()?.join(p.strip_prefix("~/").unwrap())
     } else {
         p.to_path_buf()
@@ -150,9 +148,8 @@ fn get_private_key_path(identity: Option<PathBuf>) -> Result<PathBuf> {
 
 fn git_ssh_credentials_callback<'a>(identity: Option<PathBuf>) -> Result<RemoteCallbacks<'a>> {
     let private_key = get_private_key_path(identity)?;
-    println!(
-        "{} {} `{}` {}",
-        emoji::INFO,
+    info!(
+        "{} `{}` {}",
         style("Using private key:").bold(),
         style(pretty_path(&private_key)?).bold().yellow(),
         style("for git-ssh checkout").bold()
@@ -182,7 +179,7 @@ fn should_pretty_path() {
 
 /// prevents from long stupid paths, and replace the home path by the literal `$HOME`
 fn pretty_path(a: &Path) -> Result<String> {
-    #[cfg(unix)]
+    #[cfg(not(windows))]
     let home_var = "$HOME";
     #[cfg(windows)]
     let home_var = "%userprofile%";
@@ -223,7 +220,7 @@ fn git_clone_all(project_dir: &Path, args: GitConfig) -> Result<String> {
     }
 
     let mut fo = FetchOptions::new();
-    match args.kind {
+    match args.remote.as_ref() {
         RepoKind::LocalFolder => {}
         RepoKind::RemoteHttp | RepoKind::RemoteHttps => {
             let mut proxy = ProxyOptions::new();
@@ -233,6 +230,9 @@ fn git_clone_all(project_dir: &Path, args: GitConfig) -> Result<String> {
         RepoKind::RemoteSsh => {
             let callbacks = git_ssh_credentials_callback(args.identity)?;
             fo.remote_callbacks(callbacks);
+        }
+        RepoKind::RemoteGit => {
+            // todo: verify if that would just work as is
         }
         RepoKind::Invalid => {
             unreachable!()
@@ -270,7 +270,8 @@ fn git_clone_all(project_dir: &Path, args: GitConfig) -> Result<String> {
                 return Err(e.into());
             }
 
-            let path = Path::new(&*args.remote);
+            let path: &str = args.remote.as_ref();
+            let path = Path::new(path);
             if !path.exists() || !path.is_dir() {
                 return Err(e.into());
             }
@@ -326,9 +327,11 @@ pub fn init(project_dir: &Path, branch: &str, force: bool) -> Result<Repository>
 }
 
 /// determines what kind of repository we got
-fn determine_repo_kind(remote_url: &str) -> RepoKind {
-    if remote_url.starts_with("git@") {
+pub fn determine_repo_kind(remote_url: &str) -> RepoKind {
+    if remote_url.starts_with("git@") || remote_url.starts_with("ssh://") {
         RepoKind::RemoteSsh
+    } else if remote_url.starts_with("git://") {
+        RepoKind::RemoteGit
     } else if remote_url.starts_with("http://") {
         RepoKind::RemoteHttp
     } else if remote_url.starts_with("https://") {
@@ -338,6 +341,46 @@ fn determine_repo_kind(remote_url: &str) -> RepoKind {
     } else {
         RepoKind::Invalid
     }
+}
+
+pub fn find_gitconfig() -> Result<Option<PathBuf>> {
+    let gitconfig = home().map(|home| home.join(".gitconfig"))?;
+    if gitconfig.exists() {
+        return Ok(Some(gitconfig));
+    }
+
+    Ok(None)
+}
+
+/// trades urls, to replace a given repo remote url with the right on based
+/// on the `[url]` section in the `~/.gitconfig`
+pub fn resolve_instead_url(
+    remote: impl AsRef<str>,
+    gitconfig: impl AsRef<Path>,
+) -> Result<Option<String>> {
+    let gitconfig = gitconfig.as_ref();
+    let remote = remote.as_ref().to_string();
+    let config = GitConfigParser::open(gitconfig).context("Cannot read or parse .gitconfig")?;
+    Ok(config
+        .sections_by_name_with_header("url")
+        .iter()
+        .map(|(head, body)| {
+            let url = head.subsection_name.as_ref();
+            let instead_of = body
+                .value(&Key::from("insteadOf"))
+                .map(|x| std::str::from_utf8(&x[..]).unwrap().to_owned());
+            (instead_of, url)
+        })
+        .filter(|(old, new)| new.is_some() && old.is_some())
+        .map(|(old, new)| {
+            let old = old.unwrap();
+            let new = new.unwrap().to_string();
+            remote
+                .starts_with(old.as_str())
+                .then(|| remote.replace(old.as_str(), new.as_str()))
+        })
+        .flatten()
+        .next())
 }
 
 #[cfg(test)]
@@ -369,7 +412,8 @@ mod tests {
     #[test]
     fn should_not_fail_for_ssh_remote_urls() {
         let config = GitConfig::new(REPO_URL_SSH, None, None).unwrap();
-        assert_eq!(config.kind, RepoKind::RemoteSsh);
+        let kind: &RepoKind = config.remote.as_ref();
+        assert_eq!(kind, &RepoKind::RemoteSsh);
     }
 
     #[test]
@@ -380,7 +424,8 @@ mod tests {
 
     #[test]
     fn should_support_a_local_relative_path() {
-        let remote: String = GitConfig::new("src", None, None).unwrap().remote.into();
+        let config = GitConfig::new("src", None, None).unwrap();
+        let remote: &str = config.remote.as_ref();
         #[cfg(unix)]
         assert!(
             remote.ends_with("/src"),
@@ -409,11 +454,9 @@ mod tests {
         // Absolute path.
         // If this fails because you cloned this repository into a non-UTF-8 directory... all
         // I can say is you probably had it comin'.
-        let remote: String =
-            GitConfig::new(current_dir().unwrap().display().to_string(), None, None)
-                .unwrap()
-                .remote
-                .into();
+        let config =
+            GitConfig::new(current_dir().unwrap().display().to_string(), None, None).unwrap();
+        let remote: &str = config.remote.as_ref();
         #[cfg(unix)]
         assert!(remote.starts_with('/'), "remote {} starts with /", &remote);
         #[cfg(windows)]
@@ -428,31 +471,24 @@ mod tests {
     fn should_test_happy_path() {
         // Remote HTTPS URL.
         let cfg = GitConfig::new(REPO_URL, Some("main".to_owned()), None).unwrap();
+        let url: &str = cfg.remote.as_ref();
 
-        assert_eq!(cfg.remote.as_ref(), Url::parse(REPO_URL).unwrap().as_str());
+        assert_eq!(url, Url::parse(REPO_URL).unwrap().as_str());
         assert_eq!(cfg.branch, GitReference::Branch("main".to_owned()));
     }
 
     #[test]
     fn should_support_abbreviated_repository_short_urls_like() {
-        assert_eq!(
-            GitConfig::new_abbr("cargo-generate/cargo-generate", None, None)
-                .unwrap()
-                .remote
-                .as_ref(),
-            Url::parse(REPO_URL).unwrap().as_str()
-        );
+        let config = GitConfig::new_abbr("cargo-generate/cargo-generate", None, None).unwrap();
+        let url: &str = config.remote.as_ref();
+        assert_eq!(url, Url::parse(REPO_URL).unwrap().as_str());
     }
 
     #[test]
     fn should_support_abbreviated_repository_short_urls_like_for_github() {
-        assert_eq!(
-            GitConfig::new_abbr("gh:cargo-generate/cargo-generate", None, None)
-                .unwrap()
-                .remote
-                .as_ref(),
-            Url::parse(REPO_URL).unwrap().as_str()
-        );
+        let config = GitConfig::new_abbr("gh:cargo-generate/cargo-generate", None, None).unwrap();
+        let url: &str = config.remote.as_ref();
+        assert_eq!(url, Url::parse(REPO_URL).unwrap().as_str());
     }
 
     #[test]
@@ -470,5 +506,20 @@ mod tests {
             "https://gitlab.com/foo/bar.git"
         );
         assert_eq!(&abbreviated_git_url_to_full_remote("foo/bar"), "foo/bar");
+    }
+
+    #[test]
+    fn should_resolve_instead_url() {
+        let sample_config = r#"
+[url "ssh://git@github.com:"]
+    insteadOf = https://github.com/
+"#;
+        let where_gitconfig_lives = tempfile::tempdir().unwrap();
+        let gitconfig = where_gitconfig_lives.path().join(".gitconfig");
+        std::fs::write(&gitconfig, sample_config).unwrap();
+
+        // SSH, aka git@github.com: or ssh://git@github.com/
+        let x = resolve_instead_url("https://github.com/foo/bar.git", &gitconfig).unwrap();
+        assert_eq!(x.unwrap().as_str(), "ssh://git@github.com:foo/bar.git")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,15 +359,11 @@ pub(crate) fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Resu
     copy_all(src, dst)
 }
 
-fn locate_template_file<T1, T2>(
+fn locate_template_file(
     name: &str,
-    template_base_folder: T1,
-    template_folder: T2,
-) -> Result<PathBuf>
-where
-    T1: AsRef<Path>,
-    T2: AsRef<Path>,
-{
+    template_base_folder: impl AsRef<Path>,
+    template_folder: impl AsRef<Path>,
+) -> Result<PathBuf> {
     let template_base_folder = template_base_folder.as_ref();
     let mut search_folder = template_folder.as_ref().to_path_buf();
     loop {

--- a/tests/integration/git.rs
+++ b/tests/integration/git.rs
@@ -1,6 +1,10 @@
 use assert_cmd::prelude::*;
 use git2::Repository;
+use git_config::file::GitConfig;
+use git_config::parser::Key;
+use git_config::values::Value;
 use predicates::prelude::*;
+use std::ops::Deref;
 
 use crate::helpers::project::binary;
 use crate::helpers::project_builder::tmp_dir;
@@ -90,4 +94,57 @@ fn it_should_init_an_empty_git_repo_even_when_starting_from_a_repo_when_forced()
     let repo = Repository::open(&target_path.join("foo")).unwrap();
     let references = repo.references().unwrap().count();
     assert_eq!(0, references);
+}
+
+#[test]
+fn should_retrieve_an_instead_of_url() {
+    let input = r#"
+[url "ssh://git@github.com:"]
+    insteadOf = https://github.com/
+"#;
+    let mut config = GitConfig::try_from(input).unwrap();
+    let url = config
+        .value::<Value>("url", Some("ssh://git@github.com:"), "insteadOf")
+        .unwrap();
+    assert_eq!(url.to_string(), "https://github.com/");
+    config
+        .set_raw_value(
+            "url",
+            Some("ssh://git@github.com:"),
+            "insteadOf",
+            "foo".as_bytes().to_vec(),
+        )
+        .unwrap();
+}
+
+#[test]
+fn should_find_them_all() {
+    let input = r#"
+[url "ssh://git@github.com:"]
+    insteadOf = https://github.com/
+[url "ssh://git@bitbucket.org:"]
+    insteadOf = https://bitbucket.org/
+"#;
+    let config = GitConfig::try_from(input).unwrap();
+    let url = config.sections_by_name_with_header("url");
+    assert_eq!(url.len(), 2);
+
+    for (head, body) in url.iter() {
+        let url = head.subsection_name.as_ref().unwrap();
+
+        let instead_of = body.value(&Key::from("insteadOf"));
+        if url.contains("github") {
+            assert_eq!(url, "ssh://git@github.com:");
+            assert_eq!(
+                instead_of.unwrap().deref(),
+                "https://github.com/".as_bytes()
+            )
+        } else {
+            assert_eq!(url, "ssh://git@bitbucket.org:");
+            assert_eq!(
+                instead_of.unwrap().as_ref(),
+                "https://bitbucket.org/".as_bytes()
+            )
+        }
+    }
 }


### PR DESCRIPTION
- fixes #520 
- implement gitconfig parsing
- use `insteadOf` configuration if available
- log some infos about the usage of the new rewritten remote url
- update used dependencies