### PR TITLE
Use regex to validate cli defined valies

### DIFF
--- a/src/hooks/variable_mod.rs
+++ b/src/hooks/variable_mod.rs
@@ -142,7 +142,8 @@ pub fn create_module(liquid_object: Rc<RefCell<Object>>) -> Module {
     });
 
     module.set_native_fn("prompt", {
-        move |prompt: &str, default_value: &str, regex: &str| -> Result<String> {
+        move |prompt: &str, default_value: &str, s: &str| -> Result<String> {
+            Regex::new(s).map_err(|_| "Invalid regex")?; // validate the regex
             let value = prompt_for_variable(&TemplateSlots {
                 prompt: prompt.into(),
                 var_name: "".into(),
@@ -150,7 +151,7 @@ pub fn create_module(liquid_object: Rc<RefCell<Object>>) -> Module {
                     entry: Box::new(StringEntry {
                         default: Some(default_value.into()),
                         choices: None,
-                        regex: Some(Regex::new(regex).map_err(|_| "Invalid regex")?),
+                        regex: Some(s.to_string()),
                     }),
                 },
             });

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -10,7 +10,7 @@ use liquid_core::Value;
 use std::ops::Index;
 
 pub fn name() -> Result<String> {
-    let valid_ident = regex::Regex::new(r"^([a-zA-Z][a-zA-Z0-9_-]+)$")?;
+    let valid_ident = regex::Regex::new(r"^([a-zA-Z][a-zA-Z0-9_-]+)$")?.to_string();
     let project_var = TemplateSlots {
         var_name: "crate_name".into(),
         prompt: "Project Name".into(),
@@ -76,8 +76,9 @@ pub fn prompt_for_variable(variable: &TemplateSlots) -> Result<String> {
                 let default = entry.default.as_ref().map(|v| v.into());
 
                 match &entry.regex {
-                    Some(regex) => loop {
+                    Some(s) => loop {
                         let user_entry = user_question(prompt.as_str(), &default)?;
+                        let regex = regex::Regex::new(s)?;
                         if regex.is_match(&user_entry) {
                             break Ok(user_entry);
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub fn generate(mut args: Args) -> Result<()> {
     .unwrap_or_default();
 
     check_cargo_generate_version(&template_config)?;
-    let template_values = resolve_template_values(default_values, &args)?;
+    let template_values = resolve_template_values(default_values, &args, &template_config)?;
 
     let project_name = resolve_project_name(&args)?;
     let project_dir = resolve_project_dir(&project_name, &args)?;


### PR DESCRIPTION
I'm opening this PR without first fixing the many tests that I assume will break because this fix includes a slight refactor of the `TemplateSlotsTable` to take values of type `TemplateSlots`. This did end up complicating regex handling a bit since it means `TemplateSlots` and its fields (and its fields' fields and theirs and so on) now must impl `Deserialize` and `PartialEq`. The `PartialEq` requirement means that `StringEntry.regex` can't have type `Option<Regex>` since `Regex` is not also `PartialEq`. The complication here is that now every time we want to use `StringEntry.regex` we have to construct a new `Regex` instance.

In my view this all seems like a fair trade-off to avoid leaking `toml::Value` in the `Config` type, but I am also a newcomer to this code base so I don't want to overstep. I'm perfectly willing to find another way or defer to someone else who understands the code better than I. But if it is acceptable then I'll go ahead and update the presumably borked tests.

Oh yeah, I should mention -- this fixes #545 