### PR TITLE
Generate release packages for `x86_64-unknown-linux-gnu`

### DIFF
--- a/.github/workflows/release-binary-assets.yml
+++ b/.github/workflows/release-binary-assets.yml
@@ -14,6 +14,10 @@ jobs:
             os: ubuntu-latest
             cross: true
             binName: cargo-generate
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+            binName: cargo-generate
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             cross: true


### PR DESCRIPTION
Include target `x86_64-unknown-linux-gnu` in the matrix so release packages are also generated for this target.