### PR TITLE
Generate release packages for `aarch64-unknown-linux-gnu`

### DIFF
--- a/.github/workflows/release-binary-assets.yml
+++ b/.github/workflows/release-binary-assets.yml
@@ -22,6 +22,10 @@ jobs:
             os: ubuntu-latest
             cross: true
             binName: cargo-generate
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+            binName: cargo-generate
           - target: x86_64-apple-darwin
             os: macos-latest
             cross: false


### PR DESCRIPTION
Include target `aarch64-unknown-linux-gnu` in the matrix so release packages are also generated for this target.