### PR TITLE
Avoid panic caused by deleting git folders

### DIFF
--- a/.github/workflows/release-binary-assets.yml
+++ b/.github/workflows/release-binary-assets.yml
@@ -22,6 +22,10 @@ jobs:
             os: ubuntu-latest
             cross: true
             binName: cargo-generate
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+            binName: cargo-generate
           - target: x86_64-apple-darwin
             os: macos-latest
             cross: false

--- a/src/git/utils.rs
+++ b/src/git/utils.rs
@@ -42,9 +42,6 @@ pub fn clone_git_template_into_temp(
         .context("Please check if the Git user / repository exists.")?;
     let branch = get_branch_name_repo(&repo)?;
 
-    // change from git repository into normal folder.
-    // remove_history(git_clone_dir.path())?;
-
     Ok((git_clone_dir, branch))
 }
 

--- a/src/git/utils.rs
+++ b/src/git/utils.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use git2::Repository;
 use tempfile::TempDir;
 
-use super::{remove_history, RepoCloneBuilder};
+use super::RepoCloneBuilder;
 
 /// deals with `~/` and `$HOME/` prefixes
 pub fn canonicalize_path(p: impl AsRef<Path>) -> Result<PathBuf> {
@@ -43,7 +43,7 @@ pub fn clone_git_template_into_temp(
     let branch = get_branch_name_repo(&repo)?;
 
     // change from git repository into normal folder.
-    remove_history(git_clone_dir.path())?;
+    // remove_history(git_clone_dir.path())?;
 
     Ok((git_clone_dir, branch))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ use ignore_me::remove_dir_files;
 use interactive::prompt_for_variable;
 use liquid::ValueView;
 use project_variables::{StringEntry, TemplateSlots, VarInfo};
+use std::ffi::OsString;
 use std::{
     borrow::Borrow,
     cell::RefCell,
@@ -306,11 +307,15 @@ pub(crate) fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Resu
     }
     fn copy_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<()> {
         fs::create_dir_all(&dst)?;
+        let git_file_name: OsString = ".git".into();
         for src_entry in fs::read_dir(src)? {
             let src_entry = src_entry?;
             let dst_path = dst.as_ref().join(src_entry.file_name());
             let entry_type = src_entry.file_type()?;
             if entry_type.is_dir() {
+                if git_file_name == src_entry.file_name() {
+                    continue;
+                }
                 copy_dir_all(src_entry.path(), dst_path)?;
             } else if entry_type.is_file() {
                 fs::copy(src_entry.path(), dst_path)?;


### PR DESCRIPTION
the reason of https://github.com/cargo-generate/cargo-generate/issues/619  is to delete _.git_ folder, so  instead of deleting _.git_, I don't copy _.git_