### PR TITLE
Replace `structopt` by `clap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,15 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,12 +152,13 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "cargo-husky",
+ "clap",
  "console",
  "dialoguer",
  "dirs",
  "git-config",
  "git2",
- "heck 0.4.0",
+ "heck",
  "home",
  "ignore",
  "indicatif",
@@ -185,7 +177,6 @@ dependencies = [
  "sanitize-filename",
  "semver",
  "serde",
- "structopt",
  "tempfile",
  "thiserror",
  "toml",
@@ -216,17 +207,41 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -521,13 +536,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "hashbrown"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
@@ -586,6 +598,16 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -934,6 +956,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "path-absolutize"
@@ -1338,33 +1366,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1404,6 +1408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,12 +1434,9 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -1573,12 +1583,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 include = ["src/**/*", "LICENSE-*", "*.md"]
 
 [dependencies]
+clap = { version = "3.1", features = ["derive"] }
 console = "0.15"
 dialoguer = "0.10"
 dirs = "4.0"
@@ -21,7 +22,6 @@ heck = "0.4"
 walkdir = "2.3"
 remove_dir_all = "0.7"
 ignore = "0.4"
-structopt = "0.3"
 anyhow = "1.0"
 toml = "0.5"
 thiserror = "1.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,14 +8,14 @@ use clap::Parser;
 
 use crate::git;
 
-#[derive(Parser)]
+#[derive(Clone, Debug, Parser)]
 #[clap(bin_name = "cargo")]
 pub enum Cli {
     #[clap(name = "generate", visible_alias = "gen")]
     Generate(Args),
 }
 
-#[derive(Debug, Parser)]
+#[derive(Clone, Debug, Parser)]
 pub struct Args {
     /// List defined favorite templates from the config
     #[clap(

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 
 use crate::git;
 
-#[derive(Clone, Debug, Parser)]
+#[derive(Parser)]
 #[clap(bin_name = "cargo")]
 pub enum Cli {
     #[clap(name = "generate", visible_alias = "gen")]

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,6 +8,13 @@ use clap::Parser;
 
 use crate::git;
 
+#[derive(Parser)]
+#[clap(bin_name = "cargo")]
+pub enum Cli {
+    #[clap(name = "generate", visible_alias = "gen")]
+    Generate(Args),
+}
+
 #[derive(Debug, Parser)]
 pub struct Args {
     /// List defined favorite templates from the config

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,21 +4,14 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use structopt::StructOpt;
+use clap::Parser;
 
 use crate::git;
 
-#[derive(StructOpt)]
-#[structopt(bin_name = "cargo")]
-pub enum Cli {
-    #[structopt(name = "generate", visible_alias = "gen")]
-    Generate(Args),
-}
-
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Args {
     /// List defined favorite templates from the config
-    #[structopt(
+    #[clap(
         long,
         conflicts_with = "git",
         conflicts_with = "subfolder",
@@ -26,12 +19,12 @@ pub struct Args {
         conflicts_with = "branch",
         conflicts_with = "name",
         conflicts_with = "force",
-        conflicts_with = "template_values_file",
+        conflicts_with = "template-values-file",
         conflicts_with = "silent",
         conflicts_with = "vcs",
         conflicts_with = "lib",
         conflicts_with = "bin",
-        conflicts_with = "ssh_identity",
+        conflicts_with = "ssh-identity",
         conflicts_with = "define",
         conflicts_with = "init"
     )]
@@ -39,11 +32,11 @@ pub struct Args {
 
     /// Generate a favorite template as defined in the config. In case the favorite is undefined,
     /// use in place of the `--git` option, otherwise specifies the subfolder
-    #[structopt(name = "favorite|git|subfolder")]
+    #[clap(name = "favorite")]
     pub favorite: Option<String>,
 
     /// Specifies a subfolder within the template repository to be used as the actual template.
-    #[structopt()]
+    #[clap(name = "subfolder")]
     pub subfolder: Option<String>,
 
     /// Git repository to clone template from. Can be a URL (like
@@ -52,11 +45,11 @@ pub struct Args {
     ///
     /// Note that cargo generate will first attempt to interpret the `owner/repo` form as a
     /// relative path and only try a GitHub URL if the local path doesn't exist.
-    #[structopt(short, long, conflicts_with = "subfolder")]
+    #[clap(name = "git", short, long, conflicts_with = "subfolder")]
     pub git: Option<String>,
 
     /// Local path to copy the template from. Can not be specified together with --git.
-    #[structopt(
+    #[clap(
         short,
         long,
         conflicts_with = "git",
@@ -66,74 +59,74 @@ pub struct Args {
     pub path: Option<PathBuf>,
 
     /// Branch to use when installing from git
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub branch: Option<String>,
 
     /// Directory to create / project name; if the name isn't in kebab-case, it will be converted
     /// to kebab-case unless `--force` is given.
-    #[structopt(long, short)]
+    #[clap(long, short)]
     pub name: Option<String>,
 
     /// Don't convert the project name to kebab-case before creating the directory.
     /// Note that cargo generate won't overwrite an existing directory, even if `--force` is given.
-    #[structopt(long, short)]
+    #[clap(long, short)]
     pub force: bool,
 
     /// Enables more verbose output.
-    #[structopt(long, short)]
+    #[clap(long, short)]
     pub verbose: bool,
 
     /// Pass template values through a file
     /// Values should be in the format `key=value`, one per line
-    #[structopt(long)]
+    #[clap(long)]
     pub template_values_file: Option<String>,
 
     /// If silent mode is set all variables will be
     /// extracted from the template_values_file.
     /// If a value is missing the project generation will fail
-    #[structopt(long, short, requires("name"))]
+    #[clap(long, short, requires("name"))]
     pub silent: bool,
 
     /// Use specific configuration file. Defaults to $CARGO_HOME/cargo-generate or $HOME/.cargo/cargo-generate
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     pub config: Option<PathBuf>,
 
     /// Specify the VCS used to initialize the generated template.
-    #[structopt(long, default_value = "git")]
+    #[clap(long, default_value = "git")]
     pub vcs: Vcs,
 
     /// Populates a template variable `crate_type` with value `"lib"`
-    #[structopt(long, conflicts_with = "bin")]
+    #[clap(long, conflicts_with = "bin")]
     pub lib: bool,
 
     /// Populates a template variable `crate_type` with value `"bin"`
-    #[structopt(long, conflicts_with = "lib")]
+    #[clap(long, conflicts_with = "lib")]
     pub bin: bool,
 
     /// Use a different ssh identity
-    #[structopt(short = "i", long = "identity", parse(from_os_str))]
+    #[clap(short = 'i', long = "identity", parse(from_os_str))]
     pub ssh_identity: Option<PathBuf>,
 
     /// Define a value for use during template expansion
-    #[structopt(long, short, number_of_values = 1)]
+    #[clap(long, short, number_of_values = 1)]
     pub define: Vec<String>,
 
     /// Generate the template directly into the current dir. No subfolder will be created and no vcs is initialized.
-    #[structopt(long)]
+    #[clap(long)]
     pub init: bool,
 
     /// Will enforce a fresh git init on the generated project
-    #[structopt(long)]
+    #[clap(long)]
     pub force_git_init: bool,
 
     /// Allows running system commands without being prompted.
     /// Warning: Setting this flag will enable the template to run arbitrary system commands without user confirmation.
     /// Use at your own risk and be sure to review the template code beforehand.
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub allow_commands: bool,
 }
 
-#[derive(Debug, StructOpt, Clone, Copy)]
+#[derive(Debug, Parser, Clone, Copy)]
 pub enum Vcs {
     None,
     Git,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,9 @@
 use anyhow::Result;
-use cargo_generate::{generate, Args};
+use cargo_generate::{generate, Cli};
 use clap::Parser;
-use std::env;
 
 fn main() -> Result<()> {
-    let mut args = env::args().peekable();
-    let command = args.next();
-    args.next_if(|x| x.as_str() == "generate");
-
-    let args = Args::parse_from(command.into_iter().chain(args));
+    let Cli::Generate(args) = Cli::parse();
     generate(args)?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,14 @@
 use anyhow::Result;
-use cargo_generate::{generate, Cli};
-use structopt::StructOpt;
+use cargo_generate::{generate, Args};
+use clap::Parser;
+use std::env;
 
 fn main() -> Result<()> {
-    let Cli::Generate(args) = Cli::from_args();
+    let mut args = env::args().peekable();
+    let command = args.next();
+    args.next_if(|x| x.as_str() == "generate");
+
+    let args = Args::parse_from(command.into_iter().chain(args));
     generate(args)?;
 
     Ok(())


### PR DESCRIPTION
Hello there!

I made this PR to replace `structopt` by `clap`.
I also derive `Clone` and `Debug` so it will be easier to use  `Args` from the public API.

Possible breaking change but `structopt` is on maintenance since Clap v3.1.0