### PR TITLE
Override project_dir when using `generate()`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -119,8 +119,12 @@ pub struct Args {
     pub define: Vec<String>,
 
     /// Generate the template directly into the current dir. No subfolder will be created and no vcs is initialized.
-    #[clap(long)]
+    #[clap(long, conflicts_with = "destination")]
     pub init: bool,
+
+    /// Generate the template directly at the given path.
+    #[clap(long, conflicts_with = "init")]
+    pub destination: Option<PathBuf>,
 
     /// Will enforce a fresh git init on the generated project
     #[clap(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 
 fn main() -> Result<()> {
     let Cli::Generate(args) = Cli::parse();
-    generate(args, None)?;
+    generate(args)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use structopt::StructOpt;
 
 fn main() -> Result<()> {
     let Cli::Generate(args) = Cli::from_args();
-    generate(args)?;
+    generate(args, None)?;
 
     Ok(())
 }

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -391,6 +391,40 @@ version = "0.1.0"
 }
 
 #[test]
+fn it_can_generate_at_given_path() -> anyhow::Result<()> {
+    let template = tmp_dir()
+        .file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .init_git()
+        .build();
+    let dir = tmp_dir().build();
+    let dest = dir.path().join("destination");
+    fs::create_dir(&dest).expect("can create directory");
+    binary()
+        .arg("generate")
+        .arg("--git")
+        .arg(template.path())
+        .arg("--name")
+        .arg("my-proj")
+        .arg("--destination")
+        .arg(&dest)
+        .current_dir(&dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+    assert!(dir
+        .read("destination/my-proj/Cargo.toml")
+        .contains("my-proj"));
+    Ok(())
+}
+
+#[test]
 fn it_refuses_to_overwrite_files() -> anyhow::Result<()> {
     let template = tmp_dir()
         .file(

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -41,7 +41,7 @@ version = "0.1.0"
     };
     // need to cd to the dir as we aren't running in the cargo shell.
     assert!(std::env::set_current_dir(&dir.root).is_ok());
-    assert!(generate(args_exposed).is_ok());
+    assert!(generate(args_exposed, None).is_ok());
 
     assert!(dir
         .read("foobar_project/Cargo.toml")

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -36,12 +36,13 @@ version = "0.1.0"
         ssh_identity: None,
         define: vec![],
         init: false,
+        destination: None,
         force_git_init: false,
         allow_commands: false,
     };
     // need to cd to the dir as we aren't running in the cargo shell.
     assert!(std::env::set_current_dir(&dir.root).is_ok());
-    assert!(generate(args_exposed, None).is_ok());
+    assert!(generate(args_exposed).is_ok());
 
     assert!(dir
         .read("foobar_project/Cargo.toml")


### PR DESCRIPTION
Hello there!

I made this PR to add the `dest` argument to the `generate` function.

This argument override the destination of the project if we give a path to the `generate` function.
If we give `None`, the behaviour stay the same as expected.

This is a breaking change btw, if you have suggestions to avoid that?