### PR TITLE
Upgrade-from-Structopt-to-Clap-v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ heck = "0.4"
 walkdir = "2.3"
 remove_dir_all = "0.7"
 ignore = "0.4"
-structopt = "0.3"
+clap = { version = "3.1.18", features = ["derive"] }
 anyhow = "1.0"
 toml = "0.5"
 thiserror = "1.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,46 +4,115 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use structopt::StructOpt;
+use clap::Parser;
 
 use crate::git;
 
-#[derive(StructOpt)]
-#[structopt(bin_name = "cargo")]
+#[derive(Debug, Parser)]
+#[clap(bin_name = "cargo")]
 pub enum Cli {
-    #[structopt(name = "generate", visible_alias = "gen")]
+    #[clap(name = "generate", visible_alias = "gen")]
     Generate(Args),
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Args {
     /// List defined favorite templates from the config
-    #[structopt(
-        long,
-        conflicts_with = "git",
-        conflicts_with = "subfolder",
-        conflicts_with = "path",
-        conflicts_with = "branch",
-        conflicts_with = "name",
-        conflicts_with = "force",
-        conflicts_with = "template_values_file",
-        conflicts_with = "silent",
-        conflicts_with = "vcs",
-        conflicts_with = "lib",
-        conflicts_with = "bin",
-        conflicts_with = "ssh_identity",
-        conflicts_with = "define",
-        conflicts_with = "init"
+    #[clap(long,
+        conflicts_with_all(&[
+            "git",
+            "subfolder",
+            "path",
+            "branch",
+            "name",
+            "force",
+            "template-values-file",
+            "silent",
+            "vcs",
+            "lib",
+            "bin",
+            "ssh-identity",
+            "define",
+            "init",
+        ])
     )]
     pub list_favorites: bool,
 
-    /// Generate a favorite template as defined in the config. In case the favorite is undefined,
-    /// use in place of the `--git` option, otherwise specifies the subfolder
-    #[structopt(name = "favorite|git|subfolder")]
-    pub favorite: Option<String>,
+    #[clap(flatten)]
+    pub template_path: TemplatePath,
+
+    /// Directory to create / project name; if the name isn't in kebab-case, it will be converted
+    /// to kebab-case unless `--force` is given.
+    #[clap(long, short)]
+    pub name: Option<String>,
+
+    /// Don't convert the project name to kebab-case before creating the directory.
+    /// Note that cargo generate won't overwrite an existing directory, even if `--force` is given.
+    #[clap(long, short)]
+    pub force: bool,
+
+    /// Enables more verbose output.
+    #[clap(long, short)]
+    pub verbose: bool,
+
+    /// Pass template values through a file
+    /// Values should be in the format `key=value`, one per line
+    #[clap(long)]
+    pub template_values_file: Option<String>,
+
+    /// If silent mode is set all variables will be
+    /// extracted from the template_values_file.
+    /// If a value is missing the project generation will fail
+    #[clap(long, short, requires("name"))]
+    pub silent: bool,
+
+    /// Use specific configuration file. Defaults to $CARGO_HOME/cargo-generate or $HOME/.cargo/cargo-generate
+    #[clap(short, long, parse(from_os_str))]
+    pub config: Option<PathBuf>,
+
+    /// Specify the VCS used to initialize the generated template.
+    #[clap(long, default_value = "git")]
+    pub vcs: Vcs,
+
+    /// Populates a template variable `crate_type` with value `"lib"`
+    #[clap(long, conflicts_with("bin"))]
+    pub lib: bool,
+
+    /// Populates a template variable `crate_type` with value `"bin"`
+    #[clap(long, conflicts_with("lib"))]
+    pub bin: bool,
+
+    /// Use a different ssh identity
+    #[clap(short = 'i', long = "identity", parse(from_os_str))]
+    pub ssh_identity: Option<PathBuf>,
+
+    /// Define a value for use during template expansion
+    #[clap(long, short, number_of_values = 1)]
+    pub define: Vec<String>,
+
+    /// Generate the template directly into the current dir. No subfolder will be created and no vcs is initialized.
+    #[clap(long)]
+    pub init: bool,
+
+    /// Will enforce a fresh git init on the generated project
+    #[clap(long)]
+    pub force_git_init: bool,
+
+    /// Allows running system commands without being prompted.
+    /// Warning: Setting this flag will enable the template to run arbitrary system commands without user confirmation.
+    /// Use at your own risk and be sure to review the template code beforehand.
+    #[clap(short, long)]
+    pub allow_commands: bool,
+}
+
+#[derive(Debug, Parser, Default)]
+pub struct TemplatePath {
+    /// Auto attempt to use as either `--git`, `--path` or `--favorite`.
+    #[clap(index(1), required_unless_present_any(&["SpecificPath", "list-favorites"]))]
+    pub auto_path: Option<String>,
 
     /// Specifies a subfolder within the template repository to be used as the actual template.
-    #[structopt()]
+    #[clap(index(2))]
     pub subfolder: Option<String>,
 
     /// Git repository to clone template from. Can be a URL (like
@@ -52,88 +121,58 @@ pub struct Args {
     ///
     /// Note that cargo generate will first attempt to interpret the `owner/repo` form as a
     /// relative path and only try a GitHub URL if the local path doesn't exist.
-    #[structopt(short, long, conflicts_with = "subfolder")]
+    #[clap(short, long, group("SpecificPath"))]
     pub git: Option<String>,
 
-    /// Local path to copy the template from. Can not be specified together with --git.
-    #[structopt(
-        short,
-        long,
-        conflicts_with = "git",
-        conflicts_with = "favorite",
-        conflicts_with = "subfolder"
-    )]
-    pub path: Option<PathBuf>,
-
     /// Branch to use when installing from git
-    #[structopt(short, long)]
+    #[clap(short, long)]
     pub branch: Option<String>,
 
-    /// Directory to create / project name; if the name isn't in kebab-case, it will be converted
-    /// to kebab-case unless `--force` is given.
-    #[structopt(long, short)]
-    pub name: Option<String>,
+    /// Local path to copy the template from. Can not be specified together with --git.
+    #[clap(name = "path", short, long, group("SpecificPath"))]
+    pub local_path: Option<String>,
 
-    /// Don't convert the project name to kebab-case before creating the directory.
-    /// Note that cargo generate won't overwrite an existing directory, even if `--force` is given.
-    #[structopt(long, short)]
-    pub force: bool,
-
-    /// Enables more verbose output.
-    #[structopt(long, short)]
-    pub verbose: bool,
-
-    /// Pass template values through a file
-    /// Values should be in the format `key=value`, one per line
-    #[structopt(long)]
-    pub template_values_file: Option<String>,
-
-    /// If silent mode is set all variables will be
-    /// extracted from the template_values_file.
-    /// If a value is missing the project generation will fail
-    #[structopt(long, short, requires("name"))]
-    pub silent: bool,
-
-    /// Use specific configuration file. Defaults to $CARGO_HOME/cargo-generate or $HOME/.cargo/cargo-generate
-    #[structopt(short, long, parse(from_os_str))]
-    pub config: Option<PathBuf>,
-
-    /// Specify the VCS used to initialize the generated template.
-    #[structopt(long, default_value = "git")]
-    pub vcs: Vcs,
-
-    /// Populates a template variable `crate_type` with value `"lib"`
-    #[structopt(long, conflicts_with = "bin")]
-    pub lib: bool,
-
-    /// Populates a template variable `crate_type` with value `"bin"`
-    #[structopt(long, conflicts_with = "lib")]
-    pub bin: bool,
-
-    /// Use a different ssh identity
-    #[structopt(short = "i", long = "identity", parse(from_os_str))]
-    pub ssh_identity: Option<PathBuf>,
-
-    /// Define a value for use during template expansion
-    #[structopt(long, short, number_of_values = 1)]
-    pub define: Vec<String>,
-
-    /// Generate the template directly into the current dir. No subfolder will be created and no vcs is initialized.
-    #[structopt(long)]
-    pub init: bool,
-
-    /// Will enforce a fresh git init on the generated project
-    #[structopt(long)]
-    pub force_git_init: bool,
-
-    /// Allows running system commands without being prompted.
-    /// Warning: Setting this flag will enable the template to run arbitrary system commands without user confirmation.
-    /// Use at your own risk and be sure to review the template code beforehand.
-    #[structopt(short, long)]
-    pub allow_commands: bool,
+    /// Generate a favorite template as defined in the config. In case the favorite is undefined,
+    /// use in place of the `--git` option, otherwise specifies the subfolder
+    #[clap(long, group("SpecificPath"))]
+    pub favorite: Option<String>,
 }
 
-#[derive(Debug, StructOpt, Clone, Copy)]
+impl TemplatePath {
+    pub fn git(&self) -> Option<String> {
+        self.git.as_ref().cloned()
+    }
+
+    pub fn local_path(&self) -> Option<String> {
+        self.local_path.as_ref().cloned()
+    }
+
+    pub fn favorite(&self) -> Option<String> {
+        self.favorite.as_ref().cloned()
+    }
+
+    pub fn auto_path(&self) -> Option<String> {
+        if self.git.is_some() || self.local_path.is_some() || self.favorite.is_some() {
+            None
+        } else {
+            self.auto_path.clone()
+        }
+    }
+
+    pub fn branch(&self) -> Option<String> {
+        self.branch.clone()
+    }
+
+    pub fn subfolder(&self) -> Option<String> {
+        if self.git.is_some() || self.local_path.is_some() || self.favorite.is_some() {
+            self.auto_path.clone()
+        } else {
+            self.subfolder.clone()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 pub enum Vcs {
     None,
     Git,
@@ -163,5 +202,171 @@ impl Vcs {
 
     pub const fn is_none(&self) -> bool {
         matches!(self, Self::None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod list_favorites {
+        use clap::Parser;
+
+        use crate::*;
+
+        type Result = anyhow::Result<()>;
+
+        #[test]
+        fn can_be_specified_alone() -> Result {
+            let args = Args::try_parse_from(&["cmd", "--list-favorites"])?;
+            assert!(args.list_favorites);
+            assert!(args.template_path.git().is_none());
+            assert!(args.template_path.local_path().is_none());
+            assert!(args.template_path.favorite().is_none());
+            assert!(args.template_path.auto_path().is_none());
+            Ok(())
+        }
+
+        #[test]
+        fn accepts_auto_path() -> Result {
+            let args = Args::try_parse_from(&["cmd", "--list-favorites", "autopath"])?;
+            assert!(matches!(args.template_path.auto_path(), Some(s) if s=="autopath"));
+            Ok(())
+        }
+
+        #[test]
+        #[should_panic]
+        fn conflicts_with_git() {
+            Args::try_parse_from(&["cmd", "--list-favorites", "--git", "git"]).unwrap();
+        }
+
+        #[test]
+        fn accepts_favorite_path() -> Result {
+            let args = Args::try_parse_from(&["cmd", "--list-favorites", "--favorite", "fav"])?;
+            assert!(matches!(args.template_path.favorite(), Some(s) if s=="fav"));
+            Ok(())
+        }
+
+        #[test]
+        #[should_panic]
+        fn conflicts_with_path() {
+            Args::try_parse_from(&["cmd", "--list-favorites", "--path", "path"]).unwrap();
+        }
+    }
+
+    mod template_path_specified_as {
+        use clap::Parser;
+
+        use crate::*;
+
+        type Result = anyhow::Result<()>;
+
+        #[test]
+        fn auto_path() -> Result {
+            let args = Args::try_parse_from(&["cmd", "mypath"])?;
+            assert!(matches!(args.template_path.auto_path(), Some(s) if s=="mypath"));
+            assert!(args.template_path.branch().is_none());
+            assert!(args.template_path.subfolder().is_none());
+            Ok(())
+        }
+
+        #[test]
+        fn git_folder() -> Result {
+            let args = Args::try_parse_from(&["cmd", "--git", "git"])?;
+            assert!(matches!(args.template_path.git(), Some(s) if s=="git"));
+            assert!(args.template_path.branch().is_none());
+            assert!(args.template_path.subfolder().is_none());
+            Ok(())
+        }
+
+        #[test]
+        fn path_folder() -> Result {
+            let args = Args::try_parse_from(&["cmd", "--path", "path"])?;
+            assert!(matches!(args.template_path.local_path(), Some(s) if s=="path"));
+            assert!(args.template_path.branch().is_none());
+            assert!(args.template_path.subfolder().is_none());
+            Ok(())
+        }
+
+        #[test]
+        fn favorites_folder() -> Result {
+            let args = Args::try_parse_from(&["cmd", "--favorite", "fav"])?;
+            assert!(matches!(args.template_path.favorite(), Some(s) if s=="fav"));
+            assert!(args.template_path.branch().is_none());
+            assert!(args.template_path.subfolder().is_none());
+            Ok(())
+        }
+
+        #[test]
+        fn auto_path_with_subfolder() -> Result {
+            let args = Args::try_parse_from(&["cmd", "mypath", "sub"])?;
+            assert!(matches!(args.template_path.auto_path(), Some(s) if s=="mypath"));
+            assert!(args.template_path.branch().is_none());
+            assert!(matches!(args.template_path.subfolder(), Some(s) if s=="sub"));
+            Ok(())
+        }
+
+        #[test]
+        fn git_folder_with_subfolder() -> Result {
+            let args = Args::try_parse_from(&["cmd", "--git", "git", "sub"])?;
+            assert!(matches!(args.template_path.git(), Some(s) if s=="git"));
+            assert!(args.template_path.branch().is_none());
+            assert!(matches!(args.template_path.subfolder(), Some(s) if s=="sub"));
+            Ok(())
+        }
+
+        #[test]
+        fn path_folder_with_subfolder() -> Result {
+            let args = Args::try_parse_from(&["cmd", "--path", "path", "sub"])?;
+            assert!(matches!(args.template_path.local_path(), Some(s) if s=="path"));
+            assert!(args.template_path.branch().is_none());
+            assert!(matches!(args.template_path.subfolder(), Some(s) if s=="sub"));
+            Ok(())
+        }
+
+        #[test]
+        fn favorites_folder_with_subfolder() -> Result {
+            let args = Args::try_parse_from(&["cmd", "--favorite", "fav", "sub"])?;
+            assert!(matches!(args.template_path.favorite(), Some(s) if s=="fav"));
+            assert!(args.template_path.branch().is_none());
+            assert!(matches!(args.template_path.subfolder(), Some(s) if s=="sub"));
+            Ok(())
+        }
+
+        #[test]
+        fn auto_path_with_subfolder_and_branch() -> Result {
+            let args = Args::try_parse_from(&["cmd", "--branch", "branch", "mypath", "sub"])?;
+            assert!(matches!(args.template_path.auto_path(), Some(s) if s=="mypath"));
+            assert!(matches!(args.template_path.branch(), Some(s) if s=="branch"));
+            assert!(matches!(args.template_path.subfolder(), Some(s) if s=="sub"));
+            Ok(())
+        }
+
+        #[test]
+        fn git_folder_with_subfolder_and_branch() -> Result {
+            let args = Args::try_parse_from(&["cmd", "--branch", "branch", "--git", "git", "sub"])?;
+            assert!(matches!(args.template_path.git(), Some(s) if s=="git"));
+            assert!(matches!(args.template_path.branch(), Some(s) if s=="branch"));
+            assert!(matches!(args.template_path.subfolder(), Some(s) if s=="sub"));
+            Ok(())
+        }
+
+        #[test]
+        fn path_folder_with_subfolder_and_branch() -> Result {
+            let args =
+                Args::try_parse_from(&["cmd", "--branch", "branch", "--path", "path", "sub"])?;
+            assert!(matches!(args.template_path.local_path(), Some(s) if s=="path"));
+            assert!(matches!(args.template_path.branch(), Some(s) if s=="branch"));
+            assert!(matches!(args.template_path.subfolder(), Some(s) if s=="sub"));
+            Ok(())
+        }
+
+        #[test]
+        fn favorites_folder_with_subfolder_and_branch() -> Result {
+            let args =
+                Args::try_parse_from(&["cmd", "--branch", "branch", "--favorite", "fav", "sub"])?;
+            assert!(matches!(args.template_path.favorite(), Some(s) if s=="fav"));
+            assert!(matches!(args.template_path.branch(), Some(s) if s=="branch"));
+            assert!(matches!(args.template_path.subfolder(), Some(s) if s=="sub"));
+            Ok(())
+        }
     }
 }

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -14,7 +14,13 @@ pub fn list_favorites(app_config: &AppConfig, args: &Args) -> Result<()> {
             .as_ref()
             .map(|h| {
                 h.iter()
-                    .filter(|(key, _)| args.favorite.as_ref().map_or(true, |f| key.starts_with(f)))
+                    .filter(|(key, _)| {
+                        // when using `--list-favorites`, its impossible to specify a path, thus
+                        // the first unnamed parameter (auto_path) becomes a filter value!
+                        args.template_path
+                            .auto_path()
+                            .map_or(true, |f| key.starts_with(&f))
+                    })
                     .collect::<Vec<(&String, &FavoriteConfig)>>()
             })
             .unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use cargo_generate::{generate, Cli};
-use structopt::StructOpt;
+use clap::Parser;
 
 fn main() -> Result<()> {
-    let Cli::Generate(args) = Cli::from_args();
+    let Cli::Generate(args) = Cli::parse();
     generate(args)?;
 
     Ok(())

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -1,5 +1,5 @@
 use crate::helpers::project_builder::tmp_dir;
-use cargo_generate::{generate, Args, Vcs};
+use cargo_generate::{generate, Args, TemplatePath, Vcs};
 
 #[test]
 fn it_allows_generate_call_with_public_args() {
@@ -18,10 +18,11 @@ version = "0.1.0"
     let dir = tmp_dir().build();
 
     let args_exposed: Args = Args {
-        git: Some(format!("{}", template.path().display())),
-        path: None,
-        branch: Some(String::from("main")),
-        subfolder: None,
+        template_path: TemplatePath {
+            git: Some(format!("{}", template.path().display())),
+            branch: Some(String::from("main")),
+            ..Default::default()
+        },
         name: Some(String::from("foobar_project")),
         force: true,
         vcs: Vcs::Git,
@@ -30,7 +31,6 @@ version = "0.1.0"
         silent: false,
         list_favorites: false,
         config: None,
-        favorite: None,
         bin: true,
         lib: false,
         ssh_identity: None,


### PR DESCRIPTION
* Upgraded from structopt to clap v3.
* Added testcases for parsing the template path part (`--git`, `--path` and `--favorite` + auto)