### PR TITLE
Return the path of the generated project from the `generate` function

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -58,6 +58,7 @@ impl TryFrom<&Path> for AppConfig {
     }
 }
 
+/// # Panics
 pub fn app_config_path(path: &Option<PathBuf>) -> Result<PathBuf> {
     path.as_ref()
         .map(|p| p.canonicalize().unwrap())

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -1,13 +1,15 @@
 //! Module dealing with <favorite> arg passed to cargo-generate
 
 use crate::{
-    app_config::{AppConfig, FavoriteConfig},
+    app_config::{app_config_path, AppConfig, FavoriteConfig},
     emoji, GenerateArgs,
 };
 use anyhow::Result;
 use console::style;
 
-pub fn list_favorites(app_config: &AppConfig, args: &GenerateArgs) -> Result<()> {
+pub fn list_favorites(args: &GenerateArgs) -> Result<()> {
+    let app_config: AppConfig = app_config_path(&args.config)?.as_path().try_into()?;
+
     let data = {
         let mut d = app_config
             .favorites

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,9 @@ use crate::{
 };
 
 /// # Panics
-pub fn generate(app_config: AppConfig, mut args: GenerateArgs) -> Result<PathBuf> {
+pub fn generate(mut args: GenerateArgs) -> Result<PathBuf> {
+    let app_config: AppConfig = app_config_path(&args.config)?.as_path().try_into()?;
+
     if args.ssh_identity.is_none()
         && app_config.defaults.is_some()
         && app_config.defaults.as_ref().unwrap().ssh_identity.is_some()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,12 +41,13 @@ mod template_filters;
 mod template_variables;
 mod user_parsed_input;
 
+pub use crate::app_config::{app_config_path, AppConfig};
+pub use crate::favorites::list_favorites;
 pub use args::*;
 
 use anyhow::{anyhow, bail, Context, Result};
 use config::{locate_template_configs, Config, CONFIG_FILE_NAME};
 use console::style;
-use favorites::list_favorites;
 use git::DEFAULT_BRANCH;
 use hooks::{execute_post_hooks, execute_pre_hooks};
 use ignore_me::remove_dir_files;
@@ -68,19 +69,12 @@ use tempfile::TempDir;
 
 use crate::template_variables::load_env_and_args_template_values;
 use crate::{
-    app_config::{app_config_path, AppConfig},
     project_variables::ConversionError,
     template_variables::{CrateType, ProjectName},
 };
 
 /// # Panics
-pub fn generate(mut args: GenerateArgs) -> Result<()> {
-    let app_config: AppConfig = app_config_path(&args.config)?.as_path().try_into()?;
-
-    if args.list_favorites {
-        return list_favorites(&app_config, &args);
-    }
-
+pub fn generate(app_config: AppConfig, mut args: GenerateArgs) -> Result<PathBuf> {
     if args.ssh_identity.is_none()
         && app_config.defaults.is_some()
         && app_config.defaults.as_ref().unwrap().ssh_identity.is_some()
@@ -157,7 +151,8 @@ pub fn generate(mut args: GenerateArgs) -> Result<()> {
         style("New project created").bold(),
         style(&project_dir.display()).underlined()
     );
-    Ok(())
+
+    Ok(project_dir)
 }
 
 fn prepare_local_template(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,16 @@
 use anyhow::Result;
-use cargo_generate::{generate, Cli};
+use cargo_generate::{app_config_path, generate, list_favorites, AppConfig, Cli};
 use clap::Parser;
 
 fn main() -> Result<()> {
     let Cli::Generate(args) = Cli::parse();
-    generate(args)?;
+    let app_config: AppConfig = app_config_path(&args.config)?.as_path().try_into()?;
+
+    if args.list_favorites {
+        list_favorites(&app_config, &args)?;
+    } else {
+        generate(app_config, args)?;
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,14 @@
 use anyhow::Result;
-use cargo_generate::{app_config_path, generate, list_favorites, AppConfig, Cli};
+use cargo_generate::{generate, list_favorites, Cli};
 use clap::Parser;
 
 fn main() -> Result<()> {
     let Cli::Generate(args) = Cli::parse();
-    let app_config: AppConfig = app_config_path(&args.config)?.as_path().try_into()?;
 
     if args.list_favorites {
-        list_favorites(&app_config, &args)?;
+        list_favorites(&args)?;
     } else {
-        generate(app_config, args)?;
+        generate(args)?;
     }
 
     Ok(())

--- a/tests/integration/helpers/project.rs
+++ b/tests/integration/helpers/project.rs
@@ -41,13 +41,3 @@ impl Project {
         self.path().join(path).exists()
     }
 }
-
-pub fn read(path: &Path) -> String {
-    let mut ret = String::new();
-    File::open(&path)
-        .unwrap_or_else(|_| panic!("couldn't open file {:?}", path))
-        .read_to_string(&mut ret)
-        .unwrap_or_else(|_| panic!("couldn't read file {:?}", path));
-
-    ret
-}

--- a/tests/integration/helpers/project.rs
+++ b/tests/integration/helpers/project.rs
@@ -41,3 +41,13 @@ impl Project {
         self.path().join(path).exists()
     }
 }
+
+pub fn read(path: &Path) -> String {
+    let mut ret = String::new();
+    File::open(&path)
+        .unwrap_or_else(|_| panic!("couldn't open file {:?}", path))
+        .read_to_string(&mut ret)
+        .unwrap_or_else(|_| panic!("couldn't read file {:?}", path));
+
+    ret
+}

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -1,3 +1,4 @@
+use crate::helpers::project::read;
 use crate::helpers::project_builder::tmp_dir;
 use cargo_generate::{generate, GenerateArgs, TemplatePath, Vcs};
 
@@ -15,7 +16,7 @@ version = "0.1.0"
         .init_git()
         .build();
 
-    let dir = tmp_dir().build();
+    let dir = tmp_dir().build().root.into_path();
 
     let args_exposed: GenerateArgs = GenerateArgs {
         template_path: TemplatePath {
@@ -45,13 +46,11 @@ version = "0.1.0"
     };
 
     // need to cd to the dir as we aren't running in the cargo shell.
-    assert!(std::env::set_current_dir(&dir.root).is_ok());
+    assert!(std::env::set_current_dir(&dir).is_ok());
     assert_eq!(
         generate(args_exposed).expect("cannot generate project"),
-        dir.path().join("foobar_project")
+        dir.join("foobar_project")
     );
 
-    assert!(dir
-        .read("foobar_project/Cargo.toml")
-        .contains("foobar_project"));
+    assert!(read(&dir.join("foobar_project").join("Cargo.toml")).contains("foobar_project"));
 }

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -1,4 +1,3 @@
-use crate::helpers::project::read;
 use crate::helpers::project_builder::tmp_dir;
 use cargo_generate::{generate, GenerateArgs, TemplatePath, Vcs};
 
@@ -40,5 +39,9 @@ fn it_allows_generate_call_with_public_args_and_returns_the_generated_path() {
         dir.join("foobar_project")
     );
 
-    assert!(read(&dir.join("foobar_project").join("Cargo.toml")).contains("foobar_project"));
+    assert!(
+        std::fs::read_to_string(&dir.join("foobar_project").join("Cargo.toml"))
+            .expect("cannot read file")
+            .contains("foobar_project")
+    );
 }

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -4,17 +4,7 @@ use cargo_generate::{generate, GenerateArgs, TemplatePath, Vcs};
 
 #[test]
 fn it_allows_generate_call_with_public_args_and_returns_generated_path() {
-    let template = tmp_dir()
-        .file(
-            "Cargo.toml",
-            r#"[package]
-name = "{{project-name}}"
-description = "A wonderful project"
-version = "0.1.0"
-"#,
-        )
-        .init_git()
-        .build();
+    let template = tmp_dir().init_default_template().init_git().build();
 
     let dir = tmp_dir().build().root.into_path();
 
@@ -40,13 +30,11 @@ version = "0.1.0"
         ssh_identity: None,
         define: vec![],
         init: false,
-        destination: None,
+        destination: Some(dir.clone()),
         force_git_init: false,
         allow_commands: false,
     };
 
-    // need to cd to the dir as we aren't running in the cargo shell.
-    assert!(std::env::set_current_dir(&dir).is_ok());
     assert_eq!(
         generate(args_exposed).expect("cannot generate project"),
         dir.join("foobar_project")

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -55,3 +55,53 @@ version = "0.1.0"
         .read("foobar_project/Cargo.toml")
         .contains("foobar_project"));
 }
+
+#[test]
+fn it_returns_the_generated_path() {
+    let template = tmp_dir()
+        .file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .init_git()
+        .build();
+
+    let dir = tmp_dir().build();
+
+    let args_exposed: GenerateArgs = GenerateArgs {
+        template_path: TemplatePath {
+            auto_path: None,
+            git: Some(format!("{}", template.path().display())),
+            branch: Some(String::from("main")),
+            path: None,
+            favorite: None,
+            subfolder: None,
+        },
+        name: Some(String::from("barbaz_project")),
+        force: true,
+        vcs: Vcs::Git,
+        verbose: true,
+        template_values_file: None,
+        silent: false,
+        list_favorites: false,
+        config: None,
+        bin: true,
+        lib: false,
+        ssh_identity: None,
+        define: vec![],
+        init: false,
+        destination: None,
+        force_git_init: false,
+        allow_commands: false,
+    };
+
+    assert!(std::env::set_current_dir(&dir.root).is_ok());
+    assert_eq!(
+        generate(args_exposed).expect("cannot generate project"),
+        dir.root.into_path().join("barbaz_project")
+    );
+}

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -49,7 +49,7 @@ version = "0.1.0"
     #[cfg(target_os = "macos")]
     assert_eq!(
         generate(args_exposed).expect("cannot generate project"),
-        std::path::Path::from("/private")
+        std::path::PathBuf::from("/private")
             .join(dir.path())
             .join("foobar_project")
     );

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -49,7 +49,7 @@ version = "0.1.0"
     #[cfg(target_os = "macos")]
     assert_eq!(
         generate(args_exposed).expect("cannot generate project"),
-        Path::from("/private")
+        std::path::Path::from("/private")
             .join(dir.path())
             .join("foobar_project")
     );

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -46,15 +46,6 @@ version = "0.1.0"
 
     // need to cd to the dir as we aren't running in the cargo shell.
     assert!(std::env::set_current_dir(&dir.root).is_ok());
-    #[cfg(target_os = "macos")]
-    assert_eq!(
-        generate(args_exposed).expect("cannot generate project"),
-        std::path::PathBuf::from("/private")
-            .join(dir.path())
-            .join("foobar_project")
-    );
-
-    #[cfg(not(target_os = "macos"))]
     assert_eq!(
         generate(args_exposed).expect("cannot generate project"),
         dir.path().join("foobar_project")

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -1,5 +1,5 @@
 use crate::helpers::project_builder::tmp_dir;
-use cargo_generate::{generate, GenerateArgs, TemplatePath, Vcs};
+use cargo_generate::{app_config_path, generate, AppConfig, GenerateArgs, TemplatePath, Vcs};
 
 #[test]
 fn it_allows_generate_call_with_public_args() {
@@ -43,9 +43,16 @@ version = "0.1.0"
         force_git_init: false,
         allow_commands: false,
     };
+
+    let app_config: AppConfig = app_config_path(&args_exposed.config)
+        .expect("cannot get app's config path")
+        .as_path()
+        .try_into()
+        .expect("cannot parse app's config path");
+
     // need to cd to the dir as we aren't running in the cargo shell.
     assert!(std::env::set_current_dir(&dir.root).is_ok());
-    assert!(generate(args_exposed).is_ok());
+    assert!(generate(app_config, args_exposed).is_ok());
 
     assert!(dir
         .read("foobar_project/Cargo.toml")

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -2,7 +2,7 @@ use crate::helpers::project_builder::tmp_dir;
 use cargo_generate::{generate, GenerateArgs, TemplatePath, Vcs};
 
 #[test]
-fn it_allows_generate_call_with_public_args() {
+fn it_allows_generate_call_with_public_args_and_return_generated_path() {
     let template = tmp_dir()
         .file(
             "Cargo.toml",
@@ -46,61 +46,10 @@ version = "0.1.0"
 
     // need to cd to the dir as we aren't running in the cargo shell.
     assert!(std::env::set_current_dir(&dir.root).is_ok());
-    assert!(generate(args_exposed).is_ok());
-
-    assert!(dir
-        .read("foobar_project/Cargo.toml")
-        .contains("foobar_project"));
-}
-
-#[test]
-fn it_returns_the_path_of_the_generated_project() {
-    let template = tmp_dir()
-        .file(
-            "Cargo.toml",
-            r#"[package]
-name = "{{project-name}}"
-description = "A wonderful project"
-version = "0.1.0"
-"#,
-        )
-        .init_git()
-        .build();
-
-    let dir = tmp_dir().build();
-
-    let args_exposed: GenerateArgs = GenerateArgs {
-        template_path: TemplatePath {
-            auto_path: None,
-            git: Some(format!("{}", template.path().display())),
-            branch: Some(String::from("main")),
-            path: None,
-            favorite: None,
-            subfolder: None,
-        },
-        name: Some(String::from("foobar_project")),
-        force: true,
-        vcs: Vcs::Git,
-        verbose: true,
-        template_values_file: None,
-        silent: false,
-        list_favorites: false,
-        config: None,
-        bin: true,
-        lib: false,
-        ssh_identity: None,
-        define: vec![],
-        init: false,
-        destination: None,
-        force_git_init: false,
-        allow_commands: false,
-    };
-
-    // need to cd to the dir as we aren't running in the cargo shell.
-    assert!(std::env::set_current_dir(&dir.root).is_ok());
-
-    let generated_path = generate(args_exposed).expect("cannot generate project");
-    assert_eq!(generated_path, dir.path().join("foobar_project"));
+    assert_eq!(
+        generate(args_exposed).expect("cannot generate project"),
+        dir.path().join("foobar_project")
+    );
 
     assert!(dir
         .read("foobar_project/Cargo.toml")

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -2,7 +2,7 @@ use crate::helpers::project_builder::tmp_dir;
 use cargo_generate::{generate, GenerateArgs, TemplatePath, Vcs};
 
 #[test]
-fn it_allows_generate_call_with_public_args_and_return_generated_path() {
+fn it_allows_generate_call_with_public_args_and_returns_generated_path() {
     let template = tmp_dir()
         .file(
             "Cargo.toml",

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -1,5 +1,5 @@
 use crate::helpers::project_builder::tmp_dir;
-use cargo_generate::{app_config_path, generate, AppConfig, GenerateArgs, TemplatePath, Vcs};
+use cargo_generate::{generate, GenerateArgs, TemplatePath, Vcs};
 
 #[test]
 fn it_allows_generate_call_with_public_args() {
@@ -44,15 +44,63 @@ version = "0.1.0"
         allow_commands: false,
     };
 
-    let app_config: AppConfig = app_config_path(&args_exposed.config)
-        .expect("cannot get app's config path")
-        .as_path()
-        .try_into()
-        .expect("cannot parse app's config path");
+    // need to cd to the dir as we aren't running in the cargo shell.
+    assert!(std::env::set_current_dir(&dir.root).is_ok());
+    assert!(generate(args_exposed).is_ok());
+
+    assert!(dir
+        .read("foobar_project/Cargo.toml")
+        .contains("foobar_project"));
+}
+
+#[test]
+fn it_returns_the_path_of_the_generated_project() {
+    let template = tmp_dir()
+        .file(
+            "Cargo.toml",
+            r#"[package]
+name = "{{project-name}}"
+description = "A wonderful project"
+version = "0.1.0"
+"#,
+        )
+        .init_git()
+        .build();
+
+    let dir = tmp_dir().build();
+
+    let args_exposed: GenerateArgs = GenerateArgs {
+        template_path: TemplatePath {
+            auto_path: None,
+            git: Some(format!("{}", template.path().display())),
+            branch: Some(String::from("main")),
+            path: None,
+            favorite: None,
+            subfolder: None,
+        },
+        name: Some(String::from("foobar_project")),
+        force: true,
+        vcs: Vcs::Git,
+        verbose: true,
+        template_values_file: None,
+        silent: false,
+        list_favorites: false,
+        config: None,
+        bin: true,
+        lib: false,
+        ssh_identity: None,
+        define: vec![],
+        init: false,
+        destination: None,
+        force_git_init: false,
+        allow_commands: false,
+    };
 
     // need to cd to the dir as we aren't running in the cargo shell.
     assert!(std::env::set_current_dir(&dir.root).is_ok());
-    assert!(generate(app_config, args_exposed).is_ok());
+
+    let generated_path = generate(args_exposed).expect("cannot generate project");
+    assert_eq!(generated_path, dir.path().join("foobar_project"));
 
     assert!(dir
         .read("foobar_project/Cargo.toml")

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -3,7 +3,7 @@ use crate::helpers::project_builder::tmp_dir;
 use cargo_generate::{generate, GenerateArgs, TemplatePath, Vcs};
 
 #[test]
-fn it_allows_generate_call_with_public_args_and_returns_generated_path() {
+fn it_allows_generate_call_with_public_args_and_returns_the_generated_path() {
     let template = tmp_dir().init_default_template().init_git().build();
 
     let dir = tmp_dir().build().root.into_path();

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -46,6 +46,15 @@ version = "0.1.0"
 
     // need to cd to the dir as we aren't running in the cargo shell.
     assert!(std::env::set_current_dir(&dir.root).is_ok());
+    #[cfg(target_os = "macos")]
+    assert_eq!(
+        generate(args_exposed).expect("cannot generate project"),
+        Path::from("/private")
+            .join(dir.path())
+            .join("foobar_project")
+    );
+
+    #[cfg(not(target_os = "macos"))]
     assert_eq!(
         generate(args_exposed).expect("cannot generate project"),
         dir.path().join("foobar_project")
@@ -54,54 +63,4 @@ version = "0.1.0"
     assert!(dir
         .read("foobar_project/Cargo.toml")
         .contains("foobar_project"));
-}
-
-#[test]
-fn it_returns_the_generated_path() {
-    let template = tmp_dir()
-        .file(
-            "Cargo.toml",
-            r#"[package]
-name = "{{project-name}}"
-description = "A wonderful project"
-version = "0.1.0"
-"#,
-        )
-        .init_git()
-        .build();
-
-    let dir = tmp_dir().build();
-
-    let args: GenerateArgs = GenerateArgs {
-        template_path: TemplatePath {
-            auto_path: None,
-            git: Some(format!("{}", template.path().display())),
-            branch: Some(String::from("main")),
-            path: None,
-            favorite: None,
-            subfolder: None,
-        },
-        name: Some(String::from("barbaz_project")),
-        force: true,
-        vcs: Vcs::Git,
-        verbose: true,
-        template_values_file: None,
-        silent: false,
-        list_favorites: false,
-        config: None,
-        bin: true,
-        lib: false,
-        ssh_identity: None,
-        define: vec![],
-        init: false,
-        destination: None,
-        force_git_init: false,
-        allow_commands: false,
-    };
-
-    assert!(std::env::set_current_dir(&dir.root).is_ok());
-    assert_eq!(
-        generate(args).expect("cannot generate project"),
-        dir.root.into_path().join("barbaz_project")
-    );
 }

--- a/tests/integration/library.rs
+++ b/tests/integration/library.rs
@@ -72,7 +72,7 @@ version = "0.1.0"
 
     let dir = tmp_dir().build();
 
-    let args_exposed: GenerateArgs = GenerateArgs {
+    let args: GenerateArgs = GenerateArgs {
         template_path: TemplatePath {
             auto_path: None,
             git: Some(format!("{}", template.path().display())),
@@ -101,7 +101,7 @@ version = "0.1.0"
 
     assert!(std::env::set_current_dir(&dir.root).is_ok());
     assert_eq!(
-        generate(args_exposed).expect("cannot generate project"),
+        generate(args).expect("cannot generate project"),
         dir.root.into_path().join("barbaz_project")
     );
 }


### PR DESCRIPTION
Hello there!

This PR aims to return the path of the generated project from the `generate` function.
Allowing the user of the public API to re-use the path when they can't guess the folder name of the generated project.

The changes there are quite big for this not so big goal, I you have any suggestions to make it clearer.