### PR TITLE
Fix compilation failures with rustc 1.59.0

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -162,27 +162,27 @@ impl TemplatePath {
             .unwrap()
     }
 
-    pub const fn git(&self) -> Option<&(impl AsRef<str> + '_)> {
+    pub fn git(&self) -> Option<&(impl AsRef<str> + '_)> {
         self.git.as_ref()
     }
 
-    pub const fn branch(&self) -> Option<&(impl AsRef<str> + '_)> {
+    pub fn branch(&self) -> Option<&(impl AsRef<str> + '_)> {
         self.branch.as_ref()
     }
 
-    pub const fn path(&self) -> Option<&(impl AsRef<str> + '_)> {
+    pub fn path(&self) -> Option<&(impl AsRef<str> + '_)> {
         self.path.as_ref()
     }
 
-    pub const fn favorite(&self) -> Option<&(impl AsRef<str> + '_)> {
+    pub fn favorite(&self) -> Option<&(impl AsRef<str> + '_)> {
         self.favorite.as_ref()
     }
 
-    pub const fn auto_path(&self) -> Option<&(impl AsRef<str> + '_)> {
+    pub fn auto_path(&self) -> Option<&(impl AsRef<str> + '_)> {
         self.auto_path.as_ref()
     }
 
-    pub const fn subfolder(&self) -> Option<&(impl AsRef<str> + '_)> {
+    pub fn subfolder(&self) -> Option<&(impl AsRef<str> + '_)> {
         if self.git.is_some() || self.path.is_some() || self.favorite.is_some() {
             self.auto_path.as_ref()
         } else {

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -21,7 +21,7 @@ type HookResult<T> = std::result::Result<T, Box<EvalAltResult>>;
 struct CleanupJob<F: FnOnce()>(Option<F>);
 
 impl<F: FnOnce()> CleanupJob<F> {
-    pub const fn new(f: F) -> Self {
+    pub fn new(f: F) -> Self {
         Self(Some(f))
     }
 }


### PR DESCRIPTION
Errors were:
```
error[E0658]: `impl Trait` is not allowed in constant functions
   --> /home/willerz/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-generate-0.15.2/src/args.rs:165:32
    |
165 |     pub const fn git(&self) -> Option<&(impl AsRef<str> + '_)> {
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #77463 <https://github.com/rust-lang/rust/issues/77463> for more information

error[E0658]: `impl Trait` is not allowed in constant functions
   --> /home/willerz/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-generate-0.15.2/src/args.rs:169:35
    |
169 |     pub const fn branch(&self) -> Option<&(impl AsRef<str> + '_)> {
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #77463 <https://github.com/rust-lang/rust/issues/77463> for more information

error[E0658]: `impl Trait` is not allowed in constant functions
   --> /home/willerz/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-generate-0.15.2/src/args.rs:173:33
    |
173 |     pub const fn path(&self) -> Option<&(impl AsRef<str> + '_)> {
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #77463 <https://github.com/rust-lang/rust/issues/77463> for more information

error[E0658]: `impl Trait` is not allowed in constant functions
   --> /home/willerz/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-generate-0.15.2/src/args.rs:177:37
    |
177 |     pub const fn favorite(&self) -> Option<&(impl AsRef<str> + '_)> {
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #77463 <https://github.com/rust-lang/rust/issues/77463> for more information

error[E0658]: `impl Trait` is not allowed in constant functions
   --> /home/willerz/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-generate-0.15.2/src/args.rs:181:38
    |
181 |     pub const fn auto_path(&self) -> Option<&(impl AsRef<str> + '_)> {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #77463 <https://github.com/rust-lang/rust/issues/77463> for more information

error[E0658]: `impl Trait` is not allowed in constant functions
   --> /home/willerz/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-generate-0.15.2/src/args.rs:185:38
    |
185 |     pub const fn subfolder(&self) -> Option<&(impl AsRef<str> + '_)> {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #77463 <https://github.com/rust-lang/rust/issues/77463> for more information

For more information about this error, try `rustc --explain E0658`.
```
and
```
error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
  --> src/hooks/mod.rs:23:6
   |
23 | impl<F: FnOnce()> CleanupJob<F> {
   |      ^
24 |     pub const fn new(f: F) -> Self {
   |     ------------------------------ function declared as const here
   |
   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
```