### PR TITLE
Add the `current_year` placeholder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "cargo-husky",
+ "chrono",
  "clap",
  "console",
  "dialoguer",
@@ -172,6 +173,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time 0.1.44",
+ "winapi",
+]
 
 [[package]]
 name = "clap"
@@ -417,7 +431,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -843,7 +857,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde",
- "time",
+ "time 0.3.9",
 ]
 
 [[package]]
@@ -868,7 +882,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "regex",
- "time",
+ "time 0.3.9",
  "unicode-segmentation",
 ]
 
@@ -948,6 +962,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1563,6 +1587,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
@@ -1697,6 +1732,12 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ include = ["src/**/*", "LICENSE-*", "*.md"]
 [dependencies]
 clap = { version = "3.2", features = ["derive", "std"], default-features = false }
 git2 = { version = "0.14", features = ["ssh", "https", "vendored-libgit2", "vendored-openssl"], default-features = false }
+chrono = "0.4"
 console = "0.15"
 dialoguer = "0.10"
 dirs = "4.0"

--- a/src/project_variables.rs
+++ b/src/project_variables.rs
@@ -65,7 +65,10 @@ pub enum ConversionError {
         regex: String,
         error: regex::Error,
     },
-    #[error("placeholder `{var_name}` is not valid as you can't override `project-name`, `crate_name`, `crate_type`, `authors` and `os-arch`")]
+    #[error(
+        "placeholder `{var_name}` is not valid as you can't override `project-name`, `crate_name` \
+            , `crate_type`, `authors`, `os-arch` and `current_year`"
+    )]
     InvalidPlaceholderName { var_name: String },
 }
 
@@ -81,7 +84,7 @@ enum SupportedVarType {
     String,
 }
 
-const RESERVED_NAMES: [&str; 7] = [
+const RESERVED_NAMES: [&str; 8] = [
     "authors",
     "os-arch",
     "project-name",
@@ -89,6 +92,7 @@ const RESERVED_NAMES: [&str; 7] = [
     "crate_type",
     "within_cargo_project",
     "is_init",
+    "current_year",
 ];
 
 pub fn fill_project_variables<F>(

--- a/src/template.rs
+++ b/src/template.rs
@@ -12,7 +12,9 @@ use crate::filenames::substitute_filename;
 use crate::include_exclude::*;
 use crate::progressbar::spinner;
 use crate::template_filters::*;
-use crate::template_variables::{get_authors, get_os_arch, Authors, CrateType, ProjectName};
+use crate::template_variables::{
+    get_authors, get_current_year, get_os_arch, Authors, CrateType, ProjectName,
+};
 use crate::user_parsed_input::UserParsedInput;
 use crate::{emoji, GenerateArgs};
 
@@ -43,6 +45,7 @@ pub fn create_liquid_object(
         .force
         .then(|| name.raw())
         .unwrap_or_else(|| name.kebab_case());
+    let current_year = get_current_year();
 
     let mut liquid_object = Object::new();
     liquid_object.insert("project-name".into(), Value::Scalar(project_name.into()));
@@ -63,6 +66,7 @@ pub fn create_liquid_object(
         "is_init".into(),
         Value::Scalar(source_template.init().into()),
     );
+    liquid_object.insert("current_year".into(), Value::Scalar(current_year.into()));
 
     Ok(liquid_object)
 }

--- a/src/template_variables/current_year.rs
+++ b/src/template_variables/current_year.rs
@@ -1,0 +1,5 @@
+use chrono::Datelike;
+
+pub fn get_current_year() -> i32 {
+    chrono::Local::now().date().year()
+}

--- a/src/template_variables/mod.rs
+++ b/src/template_variables/mod.rs
@@ -1,5 +1,6 @@
 mod authors;
 mod crate_type;
+mod current_year;
 mod os_arch;
 mod project_name;
 
@@ -14,6 +15,7 @@ use toml::Value;
 
 pub use authors::{get_authors, Authors};
 pub use crate_type::CrateType;
+pub use current_year::get_current_year;
 pub use os_arch::get_os_arch;
 pub use project_name::ProjectName;
 


### PR DESCRIPTION
Hello there, this PR aims to add the `current_year` placeholder.

I seen that the `it_subsitute_date()` test exists but I didn't seen much documentation about that. This placeholder will replace `{{current_year}}` with the current year using [chrono::Local](https://docs.rs/chrono/latest/chrono/offset/struct.Local.html) instead of a formatted given date.