### PR TITLE
renaming files by using e.g. `{{project-name}}.yml` as filename doesn't remove the original file

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -152,6 +152,9 @@ pub fn walk_dir(
                                     style(new_filename.display()).bold()
                                 )
                             })?;
+                            if filename != new_filename {
+                                fs::remove_file(filename)?;
+                            }
                             pb.inc(50);
                             pb.finish_with_message(format!("Done: {}", f));
                         }

--- a/tests/integration/filenames.rs
+++ b/tests/integration/filenames.rs
@@ -37,15 +37,19 @@ fn it_substitutes_filename() {
         "project should contain foobar-project/main.rs"
     );
     assert!(
+        !dir.exists("foobar-project/{{project-name}}.rs"),
+        "project should NOT contain foobar-project/{{project-name}}.rs"
+    );
+    assert!(
         dir.exists("foobar-project/foobar-project.rs"),
         "project should contain foobar-project/foobar-project.rs"
     );
     assert!(
-        dir.exists("foobar-project/src/foobar-project/lib.rs"),
-        "project should contain foobar-project/src/foobar-project/lib.rs"
+        !dir.exists("foobar-project/src/{{project-name}}/lib.rs"),
+        "project should NOT contain foobar-project/src/foobar-project/lib.rs.liquid"
     );
     assert!(
-        !dir.exists("foobar-project/src/{{project-name}}/lib.rs"),
-        "project should not contain foobar-project/src/foobar-project/lib.rs.liquid"
+        dir.exists("foobar-project/src/foobar-project/lib.rs"),
+        "project should contain foobar-project/src/foobar-project/lib.rs"
     );
 }


### PR DESCRIPTION
Fixes #701