### PR TITLE
Deleting_a_non_existing_file_should_not_fail

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,13 +17,13 @@ pub struct Config {
     pub conditional: Option<HashMap<String, ConditionalConfig>>,
 }
 
-#[derive(Deserialize, Debug, PartialEq, Default, Clone)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Default, Clone)]
 pub struct HooksConfig {
     pub pre: Option<Vec<String>>,
     pub post: Option<Vec<String>>,
 }
 
-#[derive(Deserialize, Debug, PartialEq, Default, Clone)]
+#[derive(Deserialize, Debug, PartialEq, Eq, Default, Clone)]
 pub struct TemplateConfig {
     pub sub_templates: Option<Vec<String>>,
 

--- a/src/hooks/file_mod.rs
+++ b/src/hooks/file_mod.rs
@@ -34,11 +34,13 @@ pub fn create_module(dir: &Path) -> Module {
         let dir = dir.clone();
 
         move |file: &str| -> HookResult<()> {
-            let file = to_absolute_path(&dir, file)?;
-            if file.is_file() {
-                std::fs::remove_file(file).map_err(|e| e.to_string())?;
-            } else {
-                std::fs::remove_dir_all(file).map_err(|e| e.to_string())?;
+            let path = to_absolute_path(&dir, file)?;
+            if path.exists() {
+                if path.is_file() {
+                    std::fs::remove_file(path).map_err(|e| e.to_string())?;
+                } else {
+                    std::fs::remove_dir_all(path).map_err(|e| e.to_string())?;
+                }
             }
             Ok(())
         }


### PR DESCRIPTION
After fixing the issue of cargo generate leaving the original file after renaming using placeholders, the template would fail if the template author had mittigated this by deleting the file from rhai... rhai failed if deleting a file that isn't there.