### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ For example:
 cargo generate --git https://github.com/rustwasm/wasm-pack-template
 ```
 
-Once you tested the project has been correctly cloned and setted, please to
+Once you tested the project has been correctly cloned and set, please to
 do the same with a template that contains git submodules.
 
 **2. Clone an existing template, with at least one git submodule, locally**
@@ -57,7 +57,7 @@ For example:
 cargo generate --git https://github.com/k0pernicus/cargo-template-test-submodule
 ```
 
-Please check that the project has been correctly cloned and setted, and check
+Please check that the project has been correctly cloned and set, and check
 if the repository contains initialized submodules.
 
 **Your ideas/contributions are welcome to create automated tests for this** :)

--- a/guide/src/templates/conditional.md
+++ b/guide/src/templates/conditional.md
@@ -17,7 +17,7 @@ cargo_generate_version = ">=0.10.0"
 ...
 ```
 
-This first part declares that the template requires `cargo-generate` version 0.10 or higher. In this same section the template auther may also specify the following 3 lists:
+This first part declares that the template requires `cargo-generate` version 0.10 or higher. In this same section the template author may also specify the following 3 lists:
 
 * `ignore` Files/folders on this list will be ignored entirely and are not included in the final output.
 * `include` These files will be processed for `Liquid` syntax by the template engine.
@@ -47,7 +47,7 @@ ignore = [ "src/main.rs" ]
 
 This is a conditional block.
 
-Here it has been choosen that the `src/main.rs` file must be ignored when the `crate_type` variable is equal to the string `"lib"`.
+Here it has been chosen that the `src/main.rs` file must be ignored when the `crate_type` variable is equal to the string `"lib"`.
 
 ```toml
 ...

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -18,7 +18,7 @@ mod utils;
 
 pub use utils::try_get_branch_from_path;
 
-// cargo-generate (as application) whant from git module:
+// cargo-generate (as application) want from git module:
 // 1. cloning remote
 // 2. initialize freshly generated template
 // 3. remove history from cloned template

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -24,7 +24,7 @@ pub struct UserParsedInput {
     // if template_location contains many templates user already specified one
     subfolder: Option<String>,
     // all values that user defined through:
-    // 1. envirnoment variables
+    // 1. environment variables
     // 2. configuration file
     // 3. cli arguments --define
     template_values: HashMap<String, toml::Value>,
@@ -40,7 +40,7 @@ pub struct UserParsedInput {
     force_git_init: bool,
     //TODO:
     // 1. This structure should be used instead of args
-    // 2. This struct can contains internaly args and app_config to not confuse
+    // 2. This struct can contains internally args and app_config to not confuse
     //    other developer with parsing configuration and args by themself
 }
 
@@ -195,7 +195,7 @@ impl UserParsedInput {
         // there is no specified favorite in configuration
         // this part try to guess what user wanted in order:
 
-        // 1. look for abbrevations like gh:, gl: etc.
+        // 1. look for abbreviations like gh:, gl: etc.
         let temp_location = abbreviated_git_url_to_full_remote(&fav_name).map(|git_url| {
             let git_user_in = GitUserInput::with_git_url_and_args(&git_url, args);
             TemplateLocation::from(git_user_in)
@@ -225,7 +225,7 @@ impl UserParsedInput {
             TemplateLocation::from(git_user_in)
         });
 
-        // Print information what happend to user
+        // Print information what happened to user
         let location_msg = match &temp_location {
             TemplateLocation::Git(git_user_input) => {
                 format!("git repository: {}", style(git_user_input.url()).bold())
@@ -322,7 +322,7 @@ impl UserParsedInput {
     }
 }
 
-// favorite can be in form with abbrevation what means that input is git repositoru
+// favorite can be in form with abbreviation what means that input is git repositoru
 pub fn abbreviated_git_url_to_full_remote(git: impl AsRef<str>) -> Option<String> {
     let git = git.as_ref();
     if git.len() >= 3 {

--- a/tests/integration/helpers/project_builder.rs
+++ b/tests/integration/helpers/project_builder.rs
@@ -188,7 +188,7 @@ version = "0.1.0"
                 for &(ref file, _) in self.files.iter() {
                     let path = path.join(file);
                     fs::remove_file(&path).unwrap_or_else(|_| {
-                        panic!("couldn't remove file {path:?}, after commiting tag {tag}")
+                        panic!("couldn't remove file {path:?}, after committing tag {tag}")
                     });
                 }
 

--- a/tests/integration/online.rs
+++ b/tests/integration/online.rs
@@ -1,4 +1,4 @@
-//! Thest that use real connection and working third part service.
+//! Test that use real connection and working third part service.
 //!
 //! The test are ignored by default
 //! You can run them with:


### PR DESCRIPTION
Found via `codespell -S CHANGELOG.md -L crate,nonexistant,fo,non-existant`