### PR TITLE
Extend the GitHub CI build pipeline for spellchecks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,15 @@ on:
   workflow_call:
 
 jobs:
+  typos:
+    name: typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: crate-ci/typos@master
+        with:
+          config: ./typos.toml
+
   check:
     name: check
     strategy:

--- a/guide/src/templates/scripting.hook-types.md
+++ b/guide/src/templates/scripting.hook-types.md
@@ -18,9 +18,9 @@
 ### Pre
 
 - Pre hooks are run *after all placeholders mentioned in cargo-generate.toml has been resolved*.
-- The hooks are free to add aditional variables, but its too late to influence the conditional system.
+- The hooks are free to add additional variables, but its too late to influence the conditional system.
 
-  This is a sideeffect of conditionals influencing the hooks - so placeholders need to be evaluated before the hooks are known.
+  This is a side effect of conditionals influencing the hooks - so placeholders need to be evaluated before the hooks are known.
 
 ### Post
 

--- a/src/git/utils.rs
+++ b/src/git/utils.rs
@@ -27,7 +27,7 @@ pub fn home() -> Result<PathBuf> {
     dirs::home_dir().context("$HOME was not set")
 }
 
-// clone git reposiotry into temp using libgit2
+// clone git repository into temp using libgit2
 pub fn clone_git_template_into_temp(
     git: &str,
     branch: Option<&str>,

--- a/src/hooks/variable_mod.rs
+++ b/src/hooks/variable_mod.rs
@@ -17,7 +17,7 @@ pub fn create_module(liquid_object: Rc<RefCell<Object>>) -> Module {
         let liquid_object = liquid_object.clone();
         move |name: &str| -> HookResult<bool> {
             match liquid_object.get_value(name) {
-                NamedValue::NonExistant => Ok(false),
+                NamedValue::NonExistent => Ok(false),
                 _ => Ok(true),
             }
         }
@@ -27,7 +27,7 @@ pub fn create_module(liquid_object: Rc<RefCell<Object>>) -> Module {
         let liquid_object = liquid_object.clone();
         move |name: &str| -> HookResult<Dynamic> {
             match liquid_object.get_value(name) {
-                NamedValue::NonExistant => Ok(Dynamic::from(String::from(""))),
+                NamedValue::NonExistent => Ok(Dynamic::from(String::from(""))),
                 NamedValue::Bool(v) => Ok(Dynamic::from(v)),
                 NamedValue::String(v) => Ok(Dynamic::from(v)),
             }
@@ -39,7 +39,7 @@ pub fn create_module(liquid_object: Rc<RefCell<Object>>) -> Module {
 
         move |name: &str, value: &str| -> HookResult<()> {
             match liquid_object.get_value(name) {
-                NamedValue::NonExistant | NamedValue::String(_) => {
+                NamedValue::NonExistent | NamedValue::String(_) => {
                     liquid_object.borrow_mut().insert(
                         name.to_string().into(),
                         Value::Scalar(value.to_string().into()),
@@ -56,7 +56,7 @@ pub fn create_module(liquid_object: Rc<RefCell<Object>>) -> Module {
 
         move |name: &str, value: bool| -> HookResult<()> {
             match liquid_object.get_value(name) {
-                NamedValue::NonExistant | NamedValue::Bool(_) => {
+                NamedValue::NonExistent | NamedValue::Bool(_) => {
                     liquid_object
                         .borrow_mut()
                         .insert(name.to_string().into(), Value::Scalar(value.into()));
@@ -70,7 +70,7 @@ pub fn create_module(liquid_object: Rc<RefCell<Object>>) -> Module {
     module.set_native_fn("set", {
         move |name: &str, value: Array| -> HookResult<()> {
             match liquid_object.get_value(name) {
-                NamedValue::NonExistant => {
+                NamedValue::NonExistent => {
                     let val = rhai_to_liquid_value(Dynamic::from(value))?;
                     liquid_object
                         .borrow_mut()
@@ -207,7 +207,7 @@ pub fn create_module(liquid_object: Rc<RefCell<Object>>) -> Module {
 }
 
 enum NamedValue {
-    NonExistant,
+    NonExistent,
     Bool(bool),
     String(String),
 }
@@ -230,8 +230,8 @@ impl GetNamedValue for Rc<RefCell<Object>> {
                         NamedValue::Bool,
                     )
                 })
-                .unwrap_or_else(|| NamedValue::NonExistant),
-            None => NamedValue::NonExistant,
+                .unwrap_or_else(|| NamedValue::NonExistent),
+            None => NamedValue::NonExistent,
         }
     }
 }

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -48,7 +48,7 @@ impl UserParsedInput {
     /// Try create `UserParsedInput` reading in order [`AppConfig`] and [`Args`]
     ///
     /// # Panics
-    /// This function assume that Args and AppConfig are verfied eariler and are logicly correct
+    /// This function assume that Args and AppConfig are verified earlier and are logically correct
     /// For example if both `--git` and `--path` are set this function will panic
     pub fn try_from_args_and_config(app_config: AppConfig, args: &GenerateArgs) -> Self {
         const DEFAULT_VCS: Vcs = Vcs::Git;

--- a/tests/integration/config_file/favorites.rs
+++ b/tests/integration/config_file/favorites.rs
@@ -94,7 +94,7 @@ fn favorite_subfolder_must_be_valid() {
         .arg("-n")
         .arg("outer")
         .arg(template.path())
-        .arg("non-existant")
+        .arg("non-existent")
         .current_dir(&working_dir.path())
         .assert()
         .failure(); // Error text is OS specific

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,5 @@
+[files]
+extend-exclude = ["CHANGELOG.md"]
+
+[default.extend-words]
+fo = "fo"


### PR DESCRIPTION
Resolve https://github.com/cargo-generate/cargo-generate/issues/761.

Since this is a Rust project, we'll use
https://github.com/crate-ci/typos which is equivalent to https://github.com/marketplace/actions/codespell-action and more suitable for Rust codebase.