### PR TITLE
Fix submodule test for git 2.38.1 and similar

### DIFF
--- a/tests/integration/helpers/project_builder.rs
+++ b/tests/integration/helpers/project_builder.rs
@@ -157,6 +157,8 @@ version = "0.1.0"
 
             self.submodules.iter().for_each(|(d, m)| {
                 Command::new("git")
+                    .arg("-c")
+                    .arg("protocol.file.allow=always")
                     .arg("submodule")
                     .arg("add")
                     .arg(&m)


### PR DESCRIPTION
resolves #777

Recent fixes of CVE-2022-39253 and CVE-2022-39253 in git broke submodule integration test.

This fix adds configuration option to enable necessary operations.

__I've tested this patch on Linux x86_64 with both git 2.38.1 and 2.38.0.__