### PR TITLE
Fix clippy after 1.65.0 toolchain update

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -148,16 +148,16 @@ pub fn init(project_dir: &Path, branch: Option<&str>, force: bool) -> Git2Result
         Repository::init_opts(project_dir, &opts)
     }
 
-    match Repository::discover(project_dir) {
-        Ok(repo) => {
+    Repository::discover(project_dir).map_or_else(
+        |_| just_init(project_dir, branch),
+        |repo| {
             if force {
                 Repository::open(project_dir).or_else(|_| just_init(project_dir, branch))
             } else {
                 Ok(repo)
             }
-        }
-        Err(_) => just_init(project_dir, branch),
-    }
+        },
+    )
 }
 
 /// remove context of repository by removing `.git` from filesystem

--- a/src/git/utils.rs
+++ b/src/git/utils.rs
@@ -46,10 +46,10 @@ pub fn clone_git_template_into_temp(
     if let Some(tag) = tag {
         let (object, reference) = repo.revparse_ext(tag)?;
         repo.checkout_tree(&object, None)?;
-        match reference {
-            Some(gref) => repo.set_head(gref.name().unwrap()),
-            None => repo.set_head_detached(object.id()),
-        }?;
+        reference.map_or_else(
+            || repo.set_head_detached(object.id()),
+            |gref| repo.set_head(gref.name().unwrap()),
+        )?
     }
 
     Ok((git_clone_dir, branch))

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -75,17 +75,18 @@ pub fn evaluate_script<T: Clone + 'static>(
 
     #[allow(deprecated)]
     conditional_evaluation_engine.on_var({
-        move |name, _, _| match liquid_object.get(name) {
-            Some(value) => Ok(value.as_view().as_scalar().map(|scalar| {
-                scalar.to_bool().map_or_else(
-                    || {
-                        let v = scalar.to_kstr();
-                        v.as_str().into()
-                    },
-                    |v| v.into(),
-                )
-            })),
-            None => Ok(None),
+        move |name, _, _| {
+            liquid_object.get(name).map_or(Ok(None), |value| {
+                Ok(value.as_view().as_scalar().map(|scalar| {
+                    scalar.to_bool().map_or_else(
+                        || {
+                            let v = scalar.to_kstr();
+                            v.as_str().into()
+                        },
+                        |v| v.into(),
+                    )
+                }))
+            })
         }
     });
 

--- a/src/hooks/variable_mod.rs
+++ b/src/hooks/variable_mod.rs
@@ -218,21 +218,22 @@ trait GetNamedValue {
 
 impl GetNamedValue for Rc<RefCell<Object>> {
     fn get_value(&self, name: &str) -> NamedValue {
-        match self.borrow().get(name) {
-            Some(value) => value
-                .as_scalar()
-                .map(|scalar| {
-                    scalar.to_bool().map_or_else(
-                        || {
-                            let v = scalar.to_kstr();
-                            NamedValue::String(String::from(v.as_str()))
-                        },
-                        NamedValue::Bool,
-                    )
-                })
-                .unwrap_or_else(|| NamedValue::NonExistant),
-            None => NamedValue::NonExistant,
-        }
+        self.borrow()
+            .get(name)
+            .map_or(NamedValue::NonExistant, |value| {
+                value
+                    .as_scalar()
+                    .map(|scalar| {
+                        scalar.to_bool().map_or_else(
+                            || {
+                                let v = scalar.to_kstr();
+                                NamedValue::String(String::from(v.as_str()))
+                            },
+                            NamedValue::Bool,
+                        )
+                    })
+                    .unwrap_or_else(|| NamedValue::NonExistant)
+            })
     }
 }
 

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -66,7 +66,7 @@ fn handle_string_input(
     provided_value: Option<String>,
     var_name: &str,
     entry: &StringEntry,
-    prompt: &str,
+    _prompt: &str,
 ) -> Result<String> {
     match provided_value {
         Some(value) => {
@@ -90,14 +90,10 @@ fn handle_string_input(
             }
         }
         None => {
-            let prompt = format!(
-                "{} {}",
-                prompt,
-                match &entry.default {
-                    Some(d) => format!("[default: {}]", style(d).bold()),
-                    None => "".into(),
-                }
-            );
+            let prompt = entry
+                .default
+                .as_ref()
+                .map_or_else(|| "".into(), |d| format!("[default: {}]", style(d).bold()));
             let default = entry.default.as_ref().map(|v| v.into());
 
             match &entry.regex {
@@ -176,7 +172,7 @@ fn handle_bool_input(
             let chosen = Select::with_theme(&ColorfulTheme::default())
                 .items(&choices)
                 .with_prompt(prompt)
-                .default(if default.unwrap_or(false) { 1 } else { 0 })
+                .default(usize::from(default.unwrap_or(false)))
                 .interact()?;
 
             Ok(choices.index(chosen).to_string())

--- a/src/template_variables/authors.rs
+++ b/src/template_variables/authors.rs
@@ -68,13 +68,15 @@ pub fn get_authors() -> Result<Authors> {
     }
 
     fn find_real_git_config() -> Option<GitConfig> {
-        match env::current_dir() {
-            Ok(cwd) => GitRepository::discover(cwd)
-                .and_then(|repo| repo.config())
-                .or_else(|_| GitConfig::open_default())
-                .ok(),
-            Err(_) => GitConfig::open_default().ok(),
-        }
+        env::current_dir().map_or_else(
+            |_| GitConfig::open_default().ok(),
+            |cwd| {
+                GitRepository::discover(cwd)
+                    .and_then(|repo| repo.config())
+                    .or_else(|_| GitConfig::open_default())
+                    .ok()
+            },
+        )
     }
 
     let author = match discover_author()? {

--- a/src/template_variables/mod.rs
+++ b/src/template_variables/mod.rs
@@ -81,24 +81,27 @@ fn read_template_values_from_definitions(
     let mut values = HashMap::with_capacity(definitions.len());
     let key_value_regex = Regex::new(r"^([a-zA-Z]+[a-zA-Z0-9\-_]*)\s*=\s*(.+)$").unwrap();
 
-    definitions.iter().try_fold(
-        &mut values,
-        |template_values, definition| match key_value_regex.captures(definition.as_ref()) {
-            Some(cap) => {
-                let key = cap.get(1).unwrap().as_str().to_string();
-                let value = cap.get(2).unwrap().as_str().to_string();
-                println!("{} => '{}'", key, value);
-                template_values.insert(key, Value::from(value));
-                Ok(template_values)
-            }
-            None => Err(anyhow::anyhow!(
-                "{} {} {}",
-                emoji::ERROR,
-                style("Failed to parse value:").bold().red(),
-                style(definition).bold().red(),
-            )),
-        },
-    )?;
+    definitions
+        .iter()
+        .try_fold(&mut values, |template_values, definition| {
+            key_value_regex.captures(definition.as_ref()).map_or_else(
+                || {
+                    Err(anyhow::anyhow!(
+                        "{} {} {}",
+                        emoji::ERROR,
+                        style("Failed to parse value:").bold().red(),
+                        style(definition).bold().red(),
+                    ))
+                },
+                |cap| {
+                    let key = cap.get(1).unwrap().as_str().to_string();
+                    let value = cap.get(2).unwrap().as_str().to_string();
+                    println!("{} => '{}'", key, value);
+                    template_values.insert(key, Value::from(value));
+                    Ok(template_values)
+                },
+            )
+        })?;
     Ok(values)
 }
 

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -196,7 +196,7 @@ impl UserParsedInput {
         // this part try to guess what user wanted in order:
 
         // 1. look for abbreviations like gh:, gl: etc.
-        let temp_location = abbreviated_git_url_to_full_remote(&fav_name).map(|git_url| {
+        let temp_location = abbreviated_git_url_to_full_remote(fav_name).map(|git_url| {
             let git_user_in = GitUserInput::with_git_url_and_args(&git_url, args);
             TemplateLocation::from(git_user_in)
         });

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -31,7 +31,7 @@ version = "0.1.0"
         .arg("--name")
         .arg("foobar-project")
         .arg(template.path())
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(
@@ -69,7 +69,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--path")
         .arg(template.path())
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -103,7 +103,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -138,7 +138,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .env("CARGO_EMAIL", "Email")
         .env("CARGO_NAME", "Author")
         .assert()
@@ -177,7 +177,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -204,7 +204,7 @@ fn it_substitutes_os_arch() {
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -240,7 +240,7 @@ version = "0.1.0"
         .arg("foobar_project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -272,7 +272,7 @@ extern crate {{crate_name}};
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -306,7 +306,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -336,7 +336,7 @@ version = "0.1.0"
         .arg(template.path())
         .arg("--name")
         .arg("outer")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -382,7 +382,7 @@ version = "0.1.0"
         .arg("--name")
         .arg("my-proj")
         .arg("--init")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -415,7 +415,7 @@ version = "0.1.0"
         .arg("my-proj")
         .arg("--destination")
         .arg(&dest)
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -446,7 +446,7 @@ version = "0.1.0"
         .arg("--name")
         .arg("my-proj")
         .arg("--init")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .status();
     binary()
         .arg("generate")
@@ -455,7 +455,7 @@ version = "0.1.0"
         .arg("--name")
         .arg("overwritten-proj")
         .arg("--init")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .failure();
     assert!(dir.read("Cargo.toml").contains("my-proj"));
@@ -483,7 +483,7 @@ version = "0.1.0"
         .arg("--name")
         .arg("my-proj")
         .arg("--init")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .status();
     binary()
         .arg("generate")
@@ -493,7 +493,7 @@ version = "0.1.0"
         .arg("overwritten-proj")
         .arg("--init")
         .arg("--overwrite")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success();
     assert!(dir.read("Cargo.toml").contains("overwritten-proj"));
@@ -525,7 +525,7 @@ version = "0.1.0"
         .arg("--branch")
         .arg("main")
         .arg("--force")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -568,7 +568,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -610,7 +610,7 @@ version = "0.1.0"
         .arg("--branch")
         .arg("main")
         .arg("--verbose")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("deleteme.trash").from_utf8());
@@ -641,7 +641,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -674,7 +674,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -708,7 +708,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -757,7 +757,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -798,7 +798,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -842,7 +842,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -872,7 +872,7 @@ version = "0.1.0"
     let relative_path = {
         let mut relative_path = std::path::PathBuf::new();
         relative_path.push("../");
-        relative_path.push(&template.path().file_name().unwrap().to_str().unwrap());
+        relative_path.push(template.path().file_name().unwrap().to_str().unwrap());
         relative_path
     };
 
@@ -885,7 +885,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -917,7 +917,7 @@ fn it_respects_template_branch_name() {
         .arg("foobar-project")
         .arg("--branch")
         .arg("gh-pages")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -956,7 +956,7 @@ exclude = ["excluded2"]
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -997,7 +997,7 @@ exclude = ["excluded"]
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -1045,7 +1045,7 @@ exclude = ["not-actually-excluded"]
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("both").from_utf8())
@@ -1088,7 +1088,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -1125,7 +1125,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("neither").count(0).from_utf8())
@@ -1157,7 +1157,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Removed:").count(0).from_utf8())
@@ -1194,7 +1194,7 @@ without_suffix = {{crate_name | split: "_" | first}}
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -1227,7 +1227,7 @@ fn it_processes_dot_github_directory_files() {
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -1266,7 +1266,7 @@ _This README was generated with [cargo-readme](https://github.com/livioribeiro/c
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -1304,7 +1304,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--vcs")
         .arg("nONE")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -1344,7 +1344,7 @@ vcs = "None"
         .arg(template.path())
         .arg("--name")
         .arg("foobar-project")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -1379,7 +1379,7 @@ version = "0.1.0"
         .arg("--name")
         .arg("foobar-project")
         .arg("--lib")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -1411,7 +1411,7 @@ version = "0.1.0"
         .arg(template.path())
         .arg("--name")
         .arg("foobar-project")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -1444,7 +1444,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -1477,7 +1477,7 @@ version = "0.1.0"
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -1505,7 +1505,7 @@ fn error_message_for_invalid_repo_or_user() {
         .arg("sassman/cli-template-rs-xx")
         .arg("--name")
         .arg("favorite-project")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .failure()
         .stderr(
@@ -1546,7 +1546,7 @@ fn a_template_can_specify_to_be_generated_into_cwd() -> anyhow::Result<()> {
         .arg("foobar-project")
         .arg("--branch")
         .arg("main")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());

--- a/tests/integration/conditionals.rs
+++ b/tests/integration/conditionals.rs
@@ -36,7 +36,7 @@ ignore = ["included"]
         .arg("foobar-project")
         .arg("-d")
         .arg("foo=false")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -76,7 +76,7 @@ ignore = ["included"]
         .arg("foobar-project")
         .arg("-d")
         .arg("foo=true")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -124,7 +124,7 @@ ignore = ["included"]
         .arg("foobar-project")
         .arg("-d")
         .arg("v1=true")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .failure()
         .stderr(predicates::str::contains("Error:").from_utf8());
@@ -163,7 +163,7 @@ ignore = ["included"]
         .arg("v1=true")
         .arg("-d")
         .arg("v2=true")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());

--- a/tests/integration/config_file/defaults.rs
+++ b/tests/integration/config_file/defaults.rs
@@ -34,7 +34,7 @@ fn it_uses_ssh_identity_from_defaults_config() {
         .arg("foo")
         .arg("--git")
         .arg(some_template.path())
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .assert()
         .success()
         .stdout(

--- a/tests/integration/config_file/favorites.rs
+++ b/tests/integration/config_file/favorites.rs
@@ -56,7 +56,7 @@ fn favorite_with_git_becomes_subfolder() {
         .arg("--git")
         .arg(git_template.path())
         .arg("test")
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .assert()
         .failure();
 }
@@ -84,7 +84,7 @@ fn favorite_subfolder_must_be_valid() {
         .arg("outer")
         .arg(template.path())
         .arg("Cargo.toml")
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .assert()
         .failure()
         .stderr(predicates::str::contains("must be a valid folder").from_utf8());
@@ -95,7 +95,7 @@ fn favorite_subfolder_must_be_valid() {
         .arg("outer")
         .arg(template.path())
         .arg("non-existant")
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .assert()
         .failure(); // Error text is OS specific
 
@@ -105,7 +105,7 @@ fn favorite_subfolder_must_be_valid() {
         .arg("outer")
         .arg(template.path())
         .arg(working_dir.path().parent().unwrap())
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .assert()
         .failure()
         .stderr(predicates::str::contains("Invalid subfolder.").from_utf8());
@@ -134,7 +134,7 @@ fn favorite_with_subfolder() -> anyhow::Result<()> {
         .arg("outer")
         .arg(template.path())
         .arg("inner")
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -156,7 +156,7 @@ fn it_can_use_favorites() {
         .arg("--name")
         .arg("favorite-project")
         .arg("test")
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -181,7 +181,7 @@ fn a_favorite_can_set_vcs_to_none_by_default() {
         .arg("--name")
         .arg("favorite-project")
         .arg("test")
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -202,7 +202,7 @@ fn favorites_default_to_git_if_not_defined() {
         .arg("--name")
         .arg("favorite-project")
         .arg("dummy")
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .assert()
         .failure()
         .stderr(
@@ -255,7 +255,7 @@ fn favorites_can_use_default_values() {
         .arg("--name")
         .arg("my-project")
         .arg("favorite")
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -319,7 +319,7 @@ fn favorites_default_value_can_be_overridden_by_environment() {
         .arg("--name")
         .arg("my-project")
         .arg("favorite")
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .env(
             "CARGO_GENERATE_TEMPLATE_VALUES_FILE",
             values_dir.path().join("values_file.toml"),
@@ -369,7 +369,7 @@ fn favorite_can_specify_to_be_generated_into_cwd() -> anyhow::Result<()> {
         .arg("--name")
         .arg("my-proj")
         .arg("favorite")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());

--- a/tests/integration/config_file/values.rs
+++ b/tests/integration/config_file/values.rs
@@ -40,7 +40,7 @@ fn it_accepts_default_template_values() {
         .arg("my-project")
         .arg("--git")
         .arg(template_dir.path())
-        .current_dir(&working_dir.path())
+        .current_dir(working_dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -89,7 +89,7 @@ fn it_accepts_template_values_file_from_environment() {
         .arg("foobar-project")
         .arg("--git")
         .arg(template_dir.path())
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .env(
             "CARGO_GENERATE_TEMPLATE_VALUES_FILE",
             template_dir.path().join("my-env-values.toml"),
@@ -141,7 +141,7 @@ ignore = ["included"]
         .arg("foobar-project")
         .arg("--template-values-file")
         .arg(template.path().join("my-values.toml"))
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -175,7 +175,7 @@ fn it_accepts_individual_template_values_from_environment() {
         .arg("foobar-project")
         .arg("--git")
         .arg(template.path())
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .env(
             "CARGO_GENERATE_TEMPLATE_VALUES_FILE",
             template.path().join("my-env-values.toml"),
@@ -218,7 +218,7 @@ fn it_accepts_template_values_file_via_flag() {
         .arg(template.path())
         .arg("--template-values-file")
         .arg(template.path().join("my-values.toml"))
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .env("CARGO_GENERATE_VALUE_MY_VALUE", "env-def-value")
         .assert()
         .success()
@@ -259,7 +259,7 @@ fn it_accepts_individual_template_values_via_flag() {
         .arg(template.path().join("my-values.toml"))
         .arg("--define")
         .arg("my_value=def-value")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -292,7 +292,7 @@ fn it_accepts_values_via_long_option() {
         .arg("--define")
         .arg(r#"my_value="content of my-value""#)
         .arg(template.path())
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -325,7 +325,7 @@ fn it_accepts_values_via_short_option() {
         .arg("-d")
         .arg(r#"my_value="content of my-value""#)
         .arg(template.path())
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -367,7 +367,7 @@ fn cli_value_overrides_others() {
         .arg("-d")
         .arg(r#"my_value="content of cli-value""#)
         .arg(template.path())
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -410,7 +410,7 @@ fn cli_values_are_checked_via_regex() {
         .arg(r#"my_value="content of my-value""#)
         .arg("--path")
         .arg(template.path())
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .failure();
 }

--- a/tests/integration/filenames.rs
+++ b/tests/integration/filenames.rs
@@ -27,7 +27,7 @@ fn it_substitutes_filename() {
         .arg(template.path())
         .arg("--name")
         .arg("foobar-project")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());

--- a/tests/integration/git.rs
+++ b/tests/integration/git.rs
@@ -22,7 +22,7 @@ fn it_allows_a_git_branch_to_be_specified() {
         .arg(template.path())
         .arg("--name")
         .arg("foobar-project")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -45,7 +45,7 @@ fn it_allows_a_git_tag_to_be_specified() {
         .arg(template.path())
         .arg("--name")
         .arg("foobar-project")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -66,7 +66,7 @@ fn it_removes_git_history() {
         .arg(template.path())
         .arg("--name")
         .arg("foobar-project")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -87,7 +87,7 @@ fn it_removes_git_history_also_on_local_templates() {
         .arg(template.path())
         .arg("--name")
         .arg("xyz")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -109,7 +109,7 @@ fn it_should_init_an_empty_git_repo_even_when_starting_from_a_repo_when_forced()
         .arg(template.path())
         .arg("--name")
         .arg("foo")
-        .current_dir(&target_path)
+        .current_dir(target_path)
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());

--- a/tests/integration/helpers/project_builder.rs
+++ b/tests/integration/helpers/project_builder.rs
@@ -110,7 +110,7 @@ version = "0.1.0"
 
             Command::new("git")
                 .arg("init")
-                .current_dir(&path)
+                .current_dir(path)
                 .assert()
                 .success();
 
@@ -125,7 +125,7 @@ version = "0.1.0"
                 Command::new("git")
                     .arg("add")
                     .arg("dummy.txt")
-                    .current_dir(&path)
+                    .current_dir(path)
                     .assert()
                     .success();
 
@@ -133,7 +133,7 @@ version = "0.1.0"
                     .arg("commit")
                     .arg("--message")
                     .arg("initial main commit")
-                    .current_dir(&path)
+                    .current_dir(path)
                     .assert()
                     .success();
 
@@ -143,7 +143,7 @@ version = "0.1.0"
                     .arg("checkout")
                     .arg("-b")
                     .arg(branch)
-                    .current_dir(&path)
+                    .current_dir(path)
                     .assert()
                     .success();
             }
@@ -151,7 +151,7 @@ version = "0.1.0"
             Command::new("git")
                 .arg("add")
                 .arg("--all")
-                .current_dir(&path)
+                .current_dir(path)
                 .assert()
                 .success();
 
@@ -159,9 +159,9 @@ version = "0.1.0"
                 Command::new("git")
                     .arg("submodule")
                     .arg("add")
-                    .arg(&m)
-                    .arg(&d)
-                    .current_dir(&path)
+                    .arg(m)
+                    .arg(d)
+                    .current_dir(path)
                     .assert()
                     .success();
             });
@@ -170,7 +170,7 @@ version = "0.1.0"
                 .arg("commit")
                 .arg("--message")
                 .arg("initial commit")
-                .current_dir(&path)
+                .current_dir(path)
                 .assert()
                 .success();
 
@@ -181,7 +181,7 @@ version = "0.1.0"
                     .arg(tag)
                     .arg("-m")
                     .arg(format!("our test tag {tag}"))
-                    .current_dir(&path)
+                    .current_dir(path)
                     .assert()
                     .success();
 
@@ -195,7 +195,7 @@ version = "0.1.0"
                 Command::new("git")
                     .arg("add")
                     .arg("--all")
-                    .current_dir(&path)
+                    .current_dir(path)
                     .assert()
                     .success();
 
@@ -203,7 +203,7 @@ version = "0.1.0"
                     .arg("commit")
                     .arg("--message")
                     .arg("dummy commit after tag")
-                    .current_dir(&path)
+                    .current_dir(path)
                     .assert()
                     .success();
             }
@@ -212,7 +212,7 @@ version = "0.1.0"
                 Command::new("git")
                     .arg("checkout")
                     .arg("main")
-                    .current_dir(&path)
+                    .current_dir(path)
                     .assert()
                     .success();
             } else {

--- a/tests/integration/hooks.rs
+++ b/tests/integration/hooks.rs
@@ -72,7 +72,7 @@ fn it_runs_all_hook_types() {
         .arg("-d")
         .arg("post=world")
         .arg("--allow-commands")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("init-script has run").from_utf8())
@@ -115,7 +115,7 @@ fn it_runs_system_commands() {
         .arg("-n")
         .arg("script-project")
         .arg("--allow-commands")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -151,7 +151,7 @@ fn it_fails_to_prompt_for_system_commands_in_silent_mode() {
         .arg("-n")
         .arg("script-project")
         .arg("--silent")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .failure()
         // The error message should instruct the user on how to proceed with silent mode (i.e. by setting the allow flag).
@@ -186,7 +186,7 @@ fn it_fails_when_a_system_command_returns_non_zero_exit_code() {
         .arg("-n")
         .arg("script-project")
         .arg("--allow-commands")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .failure()
         .stderr(
@@ -225,7 +225,7 @@ fn it_fails_when_it_cant_execute_system_command() {
         .arg("-n")
         .arg("script-project")
         .arg("--allow-commands")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .failure()
         .stderr(
@@ -270,7 +270,7 @@ fn it_can_change_case() {
         .arg(template.path())
         .arg("-n")
         .arg("script-project")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("kebab-case"))
@@ -315,7 +315,7 @@ fn can_change_variables_from_pre_hook() {
         .arg(template.path())
         .arg("-n")
         .arg("script-project")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -355,7 +355,7 @@ fn init_hook_can_set_project_name() {
         .arg("gen")
         .arg("--git")
         .arg(template.path())
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -399,7 +399,7 @@ fn init_hook_can_change_project_name_but_keeps_cli_name_for_destination() {
         .arg(template.path())
         .arg("--name")
         .arg("foo")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -442,7 +442,7 @@ fn init_hook_can_change_project_name_but_keeps_init_destination() {
         .arg("--name")
         .arg("foo")
         .arg("--init")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());

--- a/tests/integration/online.rs
+++ b/tests/integration/online.rs
@@ -24,7 +24,7 @@ fn git_flag_can_be_skipped_and_cargo_will_use_correct_implementation() {
         .arg("my-proj")
         .arg("--init")
         .arg("git://github.com/ashleygwilliams/wasm-pack-template")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").from_utf8());
@@ -52,7 +52,7 @@ fn plain_git_repo_works() {
             .arg("--name")
             .arg("my-proj")
             .arg("--init")
-            .current_dir(&dir.path())
+            .current_dir(dir.path())
             .assert()
             .success()
             .stdout(predicates::str::contains("Done!").from_utf8());
@@ -68,7 +68,7 @@ fn abbreviation_for_github_works() {
         .arg("--name")
         .arg("my-proj")
         .arg("ashleygwilliams/wasm-pack-template")
-        .current_dir(&dir.path())
+        .current_dir(dir.path())
         .assert()
         .success()
         .stdout(predicates::str::contains("Done!").and(
@@ -94,7 +94,7 @@ mod ssh_remote {
             .arg("git@github.com:ashleygwilliams/wasm-pack-template.git")
             .arg("--name")
             .arg("foobar-project")
-            .current_dir(&dir.path())
+            .current_dir(dir.path())
             .assert()
             .success()
             .stdout(predicates::str::contains("Done!").from_utf8());
@@ -115,7 +115,7 @@ mod ssh_remote {
             .arg("git@github.com:cargo-generate/wasm-pack-template.git")
             .arg("--name")
             .arg("foobar-project")
-            .current_dir(&dir.path())
+            .current_dir(dir.path())
             .assert()
             .success()
             .stdout(predicates::str::contains("Done!").from_utf8());
@@ -138,7 +138,7 @@ mod ssh_remote {
             .arg("git@github.com:cargo-generate/wasm-pack-template.git")
             .arg("--name")
             .arg("foobar-project")
-            .current_dir(&dir.path())
+            .current_dir(dir.path())
             .assert()
             .success()
             .stdout(


### PR DESCRIPTION
Addressing https://github.com/cargo-generate/cargo-generate/pull/778#issuecomment-1304503386

As a side note - I found it quite hard to contribute to the project because of amount of assumptions (which are not true for my setup) it makes.

- I'm using `commit.gpgsign true` in my git config and tests are picking up the global config prompting me for passphrase and making tests failed as they don't expect signing of git commits.
- I find git-hooks particularly annoying especially in combination with issues like one above. I pretty much just disabled them with `--no-verify` to be able to make any progress.

I believe that decisions like this are up to the projects maintainers to make so don't take this as criticism just a data about workflow of other people which might not have been considered. Personally I found it quite annoying since the workarounds feel like downgrade from the workflow I normally use (signing all commits or being able to run tests in specific environment I'm testing). I think the assumption that environment in which commits and pushes are made is the same environment for which code is written (and thus tests are written) for is problematic. Especially since there would be value for project like this to be able to test against specific versions of git and with various combinations of git configurations. Current philosophy though is exact opposite of that. Not only that tests depend on global git configuration but also git commit hooks enforce that even the environment from which `git push` is being made is the one in which tests pass. While in my case I'm forced to run tests as a different user to the user I'm committing as.
