### PR TITLE
build: put vendored libraries behind features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "LICENSE-*", "*.md"]
 
 [dependencies]
 clap = { version = "~4.1", features = ["derive", "std", "help"], default-features = false }
-git2 = { version = "~0.16", features = ["ssh", "https", "vendored-libgit2", "vendored-openssl"], default-features = false }
+git2 = { version = "~0.16", features = ["ssh", "https"], default-features = false }
 console = "~0.15"
 dialoguer = "~0.10"
 dirs = "~4.0"
@@ -68,7 +68,9 @@ features = [
 ]
 
 [features]
-vendored-openssl = ['openssl/vendored']
+default = ["vendored-libgit2", "vendored-openssl"]
+vendored-libgit2 = ["git2/vendored-libgit2"]
+vendored-openssl = ['openssl/vendored', "git2/vendored-openssl"]
 
 [[bin]]
 path = "src/main.rs"

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -1,26 +1,32 @@
 # Installation
 
-## Using `cargo` with system's OpenSSL
+## Using `cargo` with vendored libgit2 and OpenSSL
 
 ```sh
 cargo install cargo-generate
 ```
 
-See the [`openssl-sys` crate readme] on how to obtain the OpenSSL library for your system. Alternatively, use the `vendored-openssl` flag if you do not want to install OpenSSL.
+By default, cargo-generate uses vendored sources for libgit2 and OpenSSL,
+this would require the following dependencies on your system, as documented by the [`openssl` crate]:
 
-## Using `cargo` with vendored OpenSSL
+- A C compiler (gcc, for example)
+- perl (and perl-core)
+- make
 
-> ⚠️ NOTE: `vendored-openssl` requires the following packages to be installed:
-> - libssl-dev
-> - gcc
-> - m4
-> - ca-certificates
-> - make
-> - perl
+## Using `cargo` with system's libgit2 and OpenSSL
+
+You can opt-out of vendored libraries and use libgit2 and OpenSSL from your system
+by building cargo-generate without the default dependencies.
 
 ```sh
-cargo install cargo-generate --features vendored-openssl
+cargo install cargo-generate --no-default-features
 ```
+
+This will require the following dependencies on your system:
+
+- pkg-config
+- libgit2
+- libssl-dev (this could also be named openssl)
 
 ## Using `pacman` (Arch Linux)
 
@@ -35,6 +41,6 @@ pacman -S cargo-generate
 1. Download the binary tarball for your platform from our [releases page].
 2. Unpack the tarball and place the binary `cargo-generate` in `~/.cargo/bin/`
 
-[`openssl-sys` crate readme]: https://crates.io/crates/openssl-sys
+[`openssl` crate]: https://docs.rs/openssl
 [community repository]: https://archlinux.org/packages/community/x86_64/cargo-generate/
 [releases page]: https://github.com/cargo-generate/cargo-generate/releases


### PR DESCRIPTION
this makes it easier for downstream repos to use the system libraries without having to patch cargo-generate

`vendored-openssl` was previously not a default feature, but since we were using `git/vendored-openssl` unconditionally, it was still enabled by the default