### PR TITLE
fix(openssl): make feature `vendored-openssl` opt in by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ features = [
 [features]
 default = ["vendored-libgit2"]
 vendored-libgit2 = ["git2/vendored-libgit2"]
-vendored-openssl = ["dep:openssl", "openssl/vendored", "git2/vendored-openssl"]
+vendored-openssl = ["openssl/vendored", "git2/vendored-openssl"]
 
 [[bin]]
 path = "src/main.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ home = "~0.5"
 sanitize-filename = "~0.4"
 rhai = "~1.12"
 path-absolutize = "~3.0"
-gix-config = "~0.16.3"
+gix-config = "0.16.3"
 paste = "~1.0"
 names = { version = "~0.14", default-features = false }
 
@@ -68,9 +68,9 @@ features = [
 ]
 
 [features]
-default = ["vendored-libgit2", "vendored-openssl"]
+default = ["vendored-libgit2"]
 vendored-libgit2 = ["git2/vendored-libgit2"]
-vendored-openssl = ['openssl/vendored', "git2/vendored-openssl"]
+vendored-openssl = ["dep:openssl", "openssl/vendored", "git2/vendored-openssl"]
 
 [[bin]]
 path = "src/main.rs"

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -1,21 +1,30 @@
 # Installation
 
-## Using `cargo` with vendored libgit2 and OpenSSL
+## Using `cargo-generate` with vendored `libgit2` and system's OpenSSL
+By default, cargo-generate uses vendored sources for `libgit2` and OpenSSL that is installed on your system.
 
 ```sh
 cargo install cargo-generate
 ```
 
-By default, cargo-generate uses vendored sources for libgit2 and OpenSSL,
+This requires the following dependencies on your system:
+- `libssl-dev` (this could also be named openssl)
+
+## Using `cargo-generate` with vendored OpenSSL
+However, you can also opt in to use a vendored OpenSSL version.
+So that you don't have to have OpenSSL installed and built it on the spot.
+
 this would require the following dependencies on your system, as documented by the [`openssl` crate]:
+- A C compiler (`gcc`, for example)
+- `perl` and `perl-core`
+- `make`
 
-- A C compiler (gcc, for example)
-- perl (and perl-core)
-- make
+```sh
+cargo install cargo-generate --features vendored-openssl
+```
 
-## Using `cargo` with system's libgit2 and OpenSSL
-
-You can opt-out of vendored libraries and use libgit2 and OpenSSL from your system
+## Using `cargo-generate` with system's `libgit2` and system's OpenSSL
+You can opt-out of vendored libraries and use `libgit2` and OpenSSL from your system
 by building cargo-generate without the default dependencies.
 
 ```sh
@@ -23,10 +32,9 @@ cargo install cargo-generate --no-default-features
 ```
 
 This will require the following dependencies on your system:
-
-- pkg-config
-- libgit2
-- libssl-dev (this could also be named openssl)
+- `pkg-config`
+- `libgit2`
+- `libssl-dev` (this could also be named openssl)
 
 ## Using `pacman` (Arch Linux)
 


### PR DESCRIPTION
As reported in #883 it seems to be not that simple to build OpenSSL on windows. 
cargo-generate before the version `0.18` had vendored openssl as opt in default behaviour. That seemed to work quite ok on windows.
This PR turns back time and sets the feature `vendored-openssl` as opt-in by default.