### PR TITLE
Fix link to 'ignoring files'

### DIFF
--- a/guide/src/templates/include_exclude.md
+++ b/guide/src/templates/include_exclude.md
@@ -12,6 +12,6 @@ include = ["Cargo.toml"]
 exclude = ["*.c"]
 ```
 
-> ⚠️ NOTE: `exclude` only makes `cargo-generate` ignore any `liquid` tags in the file. In order to exclude a file from being copied to the final dir, see [ignoring files](#Ignoring-files).
+> ⚠️ NOTE: `exclude` only makes `cargo-generate` ignore any `liquid` tags in the file. In order to exclude a file from being copied to the final dir, see [ignoring files](ignoring.md).
 
 The `cargo-generate.toml` file should be placed in the root of the template. If using the `subfolder` feature, the root is the `subfolder` inside the repository, though `cargo-generate` will look for the file in all parent folders until it reaches the repository root.


### PR DESCRIPTION
Presumably this used to be a section in include_exclude.md, but is now its own page.