### PR TITLE
fix: use tempdir prefix

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,7 @@ pub fn locate_template_configs(base_dir: &Path) -> Result<Vec<PathBuf>> {
 #[cfg(test)]
 mod tests {
     use crate::tests::create_file;
+    use crate::tmp_dir;
 
     use super::*;
     use std::fs::File;
@@ -140,15 +141,9 @@ mod tests {
     use std::str::FromStr;
     use toml::Value;
 
-    fn tempdir() -> std::io::Result<tempfile::TempDir> {
-        tempfile::Builder::new()
-            .prefix("cargo-generate-test")
-            .tempdir()
-    }
-
     #[test]
     fn locate_configs_returns_empty_upon_failure() -> anyhow::Result<()> {
-        let tmp = tempdir().unwrap();
+        let tmp = tmp_dir().unwrap();
         create_file(&tmp, "dir1/Cargo.toml", "")?;
         create_file(&tmp, "dir2/dir2_1/Cargo.toml", "")?;
         create_file(&tmp, "dir3/Cargo.toml", "")?;
@@ -160,7 +155,7 @@ mod tests {
 
     #[test]
     fn locate_configs_can_locate_paths_with_cargo_generate() -> anyhow::Result<()> {
-        let tmp = tempdir().unwrap();
+        let tmp = tmp_dir().unwrap();
         create_file(&tmp, "dir1/Cargo.toml", "")?;
         create_file(&tmp, "dir2/dir2_1/Cargo.toml", "")?;
         create_file(&tmp, "dir2/dir2_2/cargo-generate.toml", "")?;
@@ -175,7 +170,7 @@ mod tests {
 
     #[test]
     fn locate_configs_doesnt_look_past_cargo_generate() -> anyhow::Result<()> {
-        let tmp = tempdir().unwrap();
+        let tmp = tmp_dir().unwrap();
         create_file(&tmp, "dir1/cargo-generate.toml", "")?;
         create_file(&tmp, "dir1/dir2/cargo-generate.toml", "")?;
 
@@ -187,7 +182,7 @@ mod tests {
 
     #[test]
     fn test_deserializes_config() {
-        let test_dir = tempdir().unwrap();
+        let test_dir = tmp_dir().unwrap();
         let config_path = test_dir.path().join(CONFIG_FILE_NAME);
         let mut file = File::create(&config_path).unwrap();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -138,8 +138,13 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
     use std::str::FromStr;
-    use tempfile::tempdir;
     use toml::Value;
+
+    fn tempdir() -> std::io::Result<tempfile::TempDir> {
+        tempfile::Builder::new()
+            .prefix("cargo-generate-test")
+            .tempdir()
+    }
 
     #[test]
     fn locate_configs_returns_empty_upon_failure() -> anyhow::Result<()> {

--- a/src/git/gitconfig.rs
+++ b/src/git/gitconfig.rs
@@ -48,13 +48,9 @@ pub fn resolve_instead_url(
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use crate::tmp_dir;
 
-    fn tempdir() -> std::io::Result<tempfile::TempDir> {
-        tempfile::Builder::new()
-            .prefix("cargo-generate-test")
-            .tempdir()
-    }
+    use super::*;
 
     #[test]
     fn should_resolve_instead_url() {
@@ -62,7 +58,7 @@ mod test {
 [url "ssh://git@github.com:"]
     insteadOf = https://github.com/
 "#;
-        let where_gitconfig_lives = tempdir().unwrap();
+        let where_gitconfig_lives = tmp_dir().unwrap();
         let gitconfig = where_gitconfig_lives.path().join(".gitconfig");
         std::fs::write(&gitconfig, sample_config).unwrap();
 

--- a/src/git/gitconfig.rs
+++ b/src/git/gitconfig.rs
@@ -50,13 +50,19 @@ pub fn resolve_instead_url(
 mod test {
     use super::*;
 
+    fn tempdir() -> std::io::Result<tempfile::TempDir> {
+        tempfile::Builder::new()
+            .prefix("cargo-generate-test")
+            .tempdir()
+    }
+
     #[test]
     fn should_resolve_instead_url() {
         let sample_config = r#"
 [url "ssh://git@github.com:"]
     insteadOf = https://github.com/
 "#;
-        let where_gitconfig_lives = tempfile::tempdir().unwrap();
+        let where_gitconfig_lives = tempdir().unwrap();
         let gitconfig = where_gitconfig_lives.path().join(".gitconfig");
         std::fs::write(&gitconfig, sample_config).unwrap();
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -14,7 +14,7 @@ mod gitconfig;
 mod identity_path;
 mod utils;
 
-pub use utils::try_get_branch_from_path;
+pub use utils::{tmp_dir, try_get_branch_from_path};
 
 // cargo-generate (as application) want from git module:
 // 1. cloning remote

--- a/src/git/utils.rs
+++ b/src/git/utils.rs
@@ -5,9 +5,11 @@ use std::path::{Path, PathBuf};
 use git2::Repository;
 use tempfile::TempDir;
 
-use crate::tmp_dir;
-
 use super::RepoCloneBuilder;
+
+pub fn tmp_dir() -> std::io::Result<tempfile::TempDir> {
+    tempfile::Builder::new().prefix("cargo-generate").tempdir()
+}
 
 /// deals with `~/` and `$HOME/` prefixes
 pub fn canonicalize_path(p: impl AsRef<Path>) -> Result<PathBuf> {

--- a/src/git/utils.rs
+++ b/src/git/utils.rs
@@ -5,6 +5,8 @@ use std::path::{Path, PathBuf};
 use git2::Repository;
 use tempfile::TempDir;
 
+use crate::tmp_dir;
+
 use super::RepoCloneBuilder;
 
 /// deals with `~/` and `$HOME/` prefixes
@@ -34,9 +36,7 @@ pub fn clone_git_template_into_temp(
     tag: Option<&str>,
     identity: Option<&Path>,
 ) -> anyhow::Result<(TempDir, String)> {
-    let git_clone_dir = tempfile::Builder::new()
-        .prefix("cargo-generate")
-        .tempdir()?;
+    let git_clone_dir = tmp_dir()?;
 
     let builder = RepoCloneBuilder::new_with(git, branch, identity)?;
 

--- a/src/git/utils.rs
+++ b/src/git/utils.rs
@@ -34,7 +34,9 @@ pub fn clone_git_template_into_temp(
     tag: Option<&str>,
     identity: Option<&Path>,
 ) -> anyhow::Result<(TempDir, String)> {
-    let git_clone_dir = tempfile::tempdir()?;
+    let git_clone_dir = tempfile::Builder::new()
+        .prefix("cargo-generate")
+        .tempdir()?;
 
     let builder = RepoCloneBuilder::new_with(git, branch, identity)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,9 @@ fn get_source_template_into_temp(
             result
         }
         TemplateLocation::Path(path) => {
-            let temp_dir = tempfile::tempdir()?;
+            let temp_dir = tempfile::Builder::new()
+                .prefix("cargo-generate")
+                .tempdir()?;
             copy_dir_all(path, temp_dir.path(), false)?;
             git::remove_history(temp_dir.path())?;
             Ok((temp_dir, try_get_branch_from_path(path)))
@@ -268,7 +270,7 @@ fn resolve_template_dir(template_base_dir: &TempDir, subfolder: Option<&str>) ->
     })
 }
 
-/// join the base-dir and the sufolder, ensuring that we stay within the template directory
+/// join the base-dir and the subfolder, ensuring that we stay within the template directory
 fn resolve_template_dir_subfolder(
     template_base_dir: &Path,
     subfolder: Option<impl AsRef<str>>,
@@ -781,7 +783,13 @@ mod tests {
         io::Write,
         path::{Path, PathBuf},
     };
-    use tempfile::{tempdir, TempDir};
+    use tempfile::TempDir;
+
+    fn tempdir() -> std::io::Result<tempfile::TempDir> {
+        tempfile::Builder::new()
+            .prefix("cargo-generate-test")
+            .tempdir()
+    }
 
     #[test]
     fn auto_locate_template_returns_base_when_no_cargo_generate_is_found() -> anyhow::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ use std::{
 use tempfile::TempDir;
 use user_parsed_input::{TemplateLocation, UserParsedInput};
 
+use crate::git::tmp_dir;
 use crate::template_variables::{
     load_env_and_args_template_values, CrateName, ProjectDir, ProjectNameInput,
 };
@@ -755,10 +756,6 @@ fn check_cargo_generate_version(template_config: &Config) -> Result<(), anyhow::
         }
     }
     Ok(())
-}
-
-pub(crate) fn tmp_dir() -> std::io::Result<tempfile::TempDir> {
-    tempfile::Builder::new().prefix("cargo-generate").tempdir()
 }
 
 #[derive(Debug)]

--- a/tests/integration/helpers/project_builder.rs
+++ b/tests/integration/helpers/project_builder.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use std::str;
 
 use crate::helpers::project::Project;
-use tempfile::{tempdir, TempDir};
+use tempfile::TempDir;
 
 pub struct ProjectBuilder {
     files: Vec<(String, String)>,
@@ -18,7 +18,10 @@ pub fn tmp_dir() -> ProjectBuilder {
     ProjectBuilder {
         files: Vec::new(),
         submodules: Vec::new(),
-        root: tempdir().unwrap(),
+        root: tempfile::Builder::new()
+            .prefix("cargo-generate-test")
+            .tempdir()
+            .unwrap(),
         git: false,
         branch: None,
         tag: None,

--- a/tests/integration/helpers/project_builder.rs
+++ b/tests/integration/helpers/project_builder.rs
@@ -19,7 +19,7 @@ pub fn tmp_dir() -> ProjectBuilder {
         files: Vec::new(),
         submodules: Vec::new(),
         root: tempfile::Builder::new()
-            .prefix("cargo-generate-test")
+            .prefix("cargo-generate")
             .tempdir()
             .unwrap(),
         git: false,


### PR DESCRIPTION
In rare cases, if a generate operation is forcefully cancelled/panics, the tempdir used for git cloning might not be cleared up.
The default `.tmp` prefix leaves the tempdir hidden and hard to know which program created it.
Having `cargo-generate` prefix adds clarity and visibility.

The same is true when running tests, for instance if you cancel the pre-push hook.