### PR TITLE
feat(error): use `fs_err` instead of `std::fs` to provide actionable error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "console",
  "dialoguer",
  "env_logger",
+ "fs-err",
  "git2",
  "gix-config",
  "heck",
@@ -472,6 +473,12 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs-err"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0845fa252299212f0389d64ba26f34fa32cfe41588355f21ed507c59a0f64541"
 
 [[package]]
 name = "fs_at"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ names = { version = "~0.14", default-features = false }
 log = "~0.4"
 env_logger = "~0.10"
 indexmap = { version = "~2", features = ["serde"] }
+fs-err = "2.9"
 
 # liquid
 liquid = "~0.26"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use config::{locate_template_configs, Config, CONFIG_FILE_NAME};
 use console::style;
 use env_logger::fmt::Formatter;
+use fs_err as fs;
 use hooks::execute_hooks;
 use ignore_me::remove_dir_files;
 use interactive::prompt_and_check_variable;
@@ -58,7 +59,7 @@ use project_variables::{StringEntry, TemplateSlots, VarInfo};
 use std::{
     cell::RefCell,
     collections::HashMap,
-    env, fs,
+    env,
     io::Write,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
@@ -248,7 +249,7 @@ fn get_source_template_into_temp(
 
 /// remove .liquid suffixes from git templates for parity with path templates
 fn strip_liquid_suffixes(dir: impl AsRef<Path>) -> Result<()> {
-    for entry in fs::read_dir(dir)? {
+    for entry in fs::read_dir(dir.as_ref())? {
         let entry = entry?;
         let entry_type = entry.file_type()?;
 
@@ -404,7 +405,7 @@ pub(crate) fn copy_dir_all(
             return Ok(());
         }
 
-        for src_entry in fs::read_dir(src)? {
+        for src_entry in fs::read_dir(src.as_ref())? {
             let src_entry = src_entry?;
             let filename = src_entry.file_name().to_string_lossy().to_string();
             let entry_type = src_entry.file_type()?;
@@ -448,7 +449,7 @@ pub(crate) fn copy_dir_all(
     }
     fn copy_all(src: impl AsRef<Path>, dst: impl AsRef<Path>, overwrite: bool) -> Result<()> {
         fs::create_dir_all(&dst)?;
-        for src_entry in fs::read_dir(src)? {
+        for src_entry in fs::read_dir(src.as_ref())? {
             let src_entry = src_entry?;
             let filename = src_entry.file_name().to_string_lossy().to_string();
             let entry_type = src_entry.file_type()?;


### PR DESCRIPTION
I.e. messages that include the file or directory that caused the error.

I was building a new template using `cargo-generate` today and I got stuck on a "File name is too long" error. No way to find out what file was causing the issue, even by passing `--verbose` to the CLI. Hence this PR!

After the change, I was able to immediately pinpoint the file and get unblocked.