### PR TITLE
feat: Add support for generating from a specific git revision of a git template

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -30,6 +30,7 @@ pub struct FavoriteConfig {
     pub git: Option<String>,
     pub branch: Option<String>,
     pub tag: Option<String>,
+    pub revision: Option<String>,
     pub subfolder: Option<String>,
     pub path: Option<PathBuf>,
     pub values: Option<HashMap<String, toml::Value>>,

--- a/src/args.rs
+++ b/src/args.rs
@@ -179,12 +179,16 @@ pub struct TemplatePath {
     pub git: Option<String>,
 
     /// Branch to use when installing from git
-    #[arg(short, long, conflicts_with = "tag")]
+    #[arg(short, long, conflicts_with_all = ["revision", "tag"])]
     pub branch: Option<String>,
 
     /// Tag to use when installing from git
-    #[arg(short, long, conflicts_with = "branch")]
+    #[arg(short, long, conflicts_with_all = ["revision", "branch"])]
     pub tag: Option<String>,
+
+    /// Git revision to use when installing from git (e.g. a commit hash)
+    #[arg(short, long, conflicts_with_all = ["tag", "branch"], alias = "rev")]
+    pub revision: Option<String>,
 
     /// Local path to copy the template from. Can not be specified together with --git.
     #[arg(short, long, group("SpecificPath"))]
@@ -219,6 +223,10 @@ impl TemplatePath {
 
     pub const fn tag(&self) -> Option<&(impl AsRef<str> + '_)> {
         self.tag.as_ref()
+    }
+
+    pub const fn revision(&self) -> Option<&(impl AsRef<str> + '_)> {
+        self.revision.as_ref()
     }
 
     pub const fn path(&self) -> Option<&(impl AsRef<str> + '_)> {

--- a/src/git/utils.rs
+++ b/src/git/utils.rs
@@ -36,6 +36,7 @@ pub fn clone_git_template_into_temp(
     git: &str,
     branch: Option<&str>,
     tag: Option<&str>,
+    revision: Option<&str>,
     identity: Option<&Path>,
 ) -> anyhow::Result<(TempDir, String)> {
     let git_clone_dir = tmp_dir()?;
@@ -47,8 +48,8 @@ pub fn clone_git_template_into_temp(
         .context("Please check if the Git user / repository exists.")?;
     let branch = get_branch_name_repo(&repo)?;
 
-    if let Some(tag) = tag {
-        let (object, reference) = repo.revparse_ext(tag)?;
+    if let Some(spec) = tag.or(revision) {
+        let (object, reference) = repo.revparse_ext(spec)?;
         repo.checkout_tree(&object, None)?;
         reference.map_or_else(
             || repo.set_head_detached(object.id()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,6 +229,7 @@ fn get_source_template_into_temp(
                 git.url(),
                 git.branch(),
                 git.tag(),
+                git.revision(),
                 git.identity(),
             )
             .map(|(dir, branch)| (dir, Some(branch)));

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -82,6 +82,7 @@ impl UserParsedInput {
                 git_url,
                 args.template_path.branch(),
                 args.template_path.tag(),
+                args.template_path.revision(),
                 ssh_identity,
                 args.force_git_init,
             );
@@ -148,10 +149,16 @@ impl UserParsedInput {
                         .tag()
                         .map(|s| s.as_ref().to_owned())
                         .or_else(|| fav_cfg.tag.clone());
+                    let revision = args
+                        .template_path
+                        .revision()
+                        .map(|s| s.as_ref().to_owned())
+                        .or_else(|| fav_cfg.revision.clone());
                     let git_user_input = GitUserInput::new(
                         git_url,
                         branch.as_ref(),
                         tag.as_ref(),
+                        revision.as_ref(),
                         ssh_identity,
                         args.force_git_init,
                     );
@@ -221,6 +228,7 @@ impl UserParsedInput {
                 &fav_name,
                 args.template_path.branch(),
                 args.template_path.tag(),
+                args.template_path.revision(),
                 ssh_identity,
                 args.force_git_init,
             );
@@ -365,6 +373,7 @@ pub struct GitUserInput {
     url: String,
     branch: Option<String>,
     tag: Option<String>,
+    revision: Option<String>,
     identity: Option<PathBuf>,
     _force_init: bool,
 }
@@ -374,6 +383,7 @@ impl GitUserInput {
         url: &impl AsRef<str>,
         branch: Option<&impl AsRef<str>>,
         tag: Option<&impl AsRef<str>>,
+        revision: Option<&impl AsRef<str>>,
         identity: Option<PathBuf>,
         force_init: bool,
     ) -> Self {
@@ -381,6 +391,7 @@ impl GitUserInput {
             url: url.as_ref().to_owned(),
             branch: branch.map(|s| s.as_ref().to_owned()),
             tag: tag.map(|s| s.as_ref().to_owned()),
+            revision: revision.map(|s| s.as_ref().to_owned()),
             identity,
             _force_init: force_init,
         }
@@ -392,6 +403,7 @@ impl GitUserInput {
             url,
             args.template_path.branch(),
             args.template_path.tag(),
+            args.template_path.revision(),
             args.ssh_identity.clone(),
             args.force_git_init,
         )
@@ -407,6 +419,10 @@ impl GitUserInput {
 
     pub fn tag(&self) -> Option<&str> {
         self.tag.as_deref()
+    }
+
+    pub fn revision(&self) -> Option<&str> {
+        self.revision.as_deref()
     }
 
     pub fn identity(&self) -> Option<&Path> {

--- a/tests/integration/git.rs
+++ b/tests/integration/git.rs
@@ -44,6 +44,26 @@ fn it_allows_a_git_tag_to_be_specified() {
 }
 
 #[test]
+fn it_allows_a_git_revision_to_be_specified() {
+    let template = tempdir().init_default_template().build();
+    let commit_sha = template.commit_shas().first().unwrap().to_string();
+    let dir = tempdir().build();
+
+    binary()
+        .arg_revision(commit_sha)
+        .arg_git(template.path())
+        .arg_name("foobar-project")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(dir
+        .read("foobar-project/Cargo.toml")
+        .contains("foobar-project"));
+}
+
+#[test]
 fn it_removes_git_history() {
     let template = tempdir().init_default_template().build();
     let dir = tempdir().build();

--- a/tests/integration/helpers/arg_builder.rs
+++ b/tests/integration/helpers/arg_builder.rs
@@ -32,6 +32,11 @@ impl CargoGenerateArgBuilder {
         self.arg("--branch").arg(name)
     }
 
+    /// wrapper for `--revision <name>` cli argument
+    pub fn arg_revision(&mut self, name: impl AsRef<OsStr>) -> &mut Self {
+        self.arg("--rev").arg(name)
+    }
+
     /// wrapper for `--git <name>` cli argument
     pub fn arg_git(&mut self, name: impl AsRef<OsStr>) -> &mut Self {
         self.arg("--git").arg(name)

--- a/tests/integration/helpers/project.rs
+++ b/tests/integration/helpers/project.rs
@@ -38,7 +38,7 @@ impl Project {
     /// Returns the commit SHAs of the commits in the current branch.
     pub fn commit_shas(&self) -> Vec<String> {
         std::process::Command::new("git")
-            .args(&["log", "--format=%h"])
+            .args(["log", "--format=%h"])
             .current_dir(self.path())
             .output()
             .expect("failed to execute `git log`")

--- a/tests/integration/helpers/project.rs
+++ b/tests/integration/helpers/project.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufRead, Read};
 use std::path::{Path, PathBuf};
 use std::str;
 
@@ -33,5 +33,18 @@ impl Project {
 
     pub fn exists(&self, path: &str) -> bool {
         self.path().join(path).exists()
+    }
+
+    /// Returns the commit SHAs of the commits in the current branch.
+    pub fn commit_shas(&self) -> Vec<String> {
+        std::process::Command::new("git")
+            .args(&["log", "--format=%h"])
+            .current_dir(self.path())
+            .output()
+            .expect("failed to execute `git log`")
+            .stdout
+            .lines()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
     }
 }

--- a/tests/integration/public_api.rs
+++ b/tests/integration/public_api.rs
@@ -16,6 +16,7 @@ fn it_allows_generate_call_with_public_args_and_returns_the_generated_path() {
             git: Some(format!("{}", template.path().display())),
             branch: Some(String::from("main")),
             tag: None,
+            revision: None,
             path: None,
             favorite: None,
             subfolder: None,


### PR DESCRIPTION
`cargo-generate` currently supports `branch` and `tag` as mechanisms to select which revision of a `git` template should be used to generate the new project.

This PR adds support for arbitrary revisions—e.g. commit SHAs.
This aligns `cargo-generate` with `cargo`, which supports `rev` as a way to specify the specific revision of a `git` dependency.

# Why?

I found myself looking for this feature when working on `pavex new` in [Pavex](https://github.com/LukeMathWalker/pavex). I want to store the template alongside the `pavex` binary and version them in lockstep: `pavex new` always relies on the template at the commit SHA that was used to compile the `pavex` binary, ensuring compatibility.