### PR TITLE
add --skip-submodules flag to optionalize cloning git submodules

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -121,7 +121,7 @@ pub struct GenerateArgs {
     #[arg(short, long, action)]
     pub overwrite: bool,
 
-    /// Download git submodules (if there are any)
+    /// Skip downloading git submodules (if there are any)
     #[arg(long, action)]
     pub skip_submodules: bool,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -121,6 +121,10 @@ pub struct GenerateArgs {
     #[arg(short, long, action)]
     pub overwrite: bool,
 
+    /// Download git submodules (if there are any)
+    #[arg(long, action)]
+    pub skip_submodules: bool,
+
     /// All args after "--" on the command line.
     #[arg(skip)]
     pub other_args: Option<Vec<String>>,
@@ -147,6 +151,7 @@ impl Default for GenerateArgs {
             force_git_init: false,
             allow_commands: false,
             overwrite: false,
+            skip_submodules: false,
             other_args: None,
         }
     }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -23,7 +23,7 @@ pub use utils::{tmp_dir, try_get_branch_from_path};
 
 // Assumptions:
 // * `--git <url>` should only be parse in the same way as `git clone <url>` would
-// * submodules can be cloned by setting the submodules field to true.
+// * submodules are cloned by default, but can be skipped by `--skip-submodules`.
 // * `.git` should be removed to make clear repository
 // * if `<url>` is the local path on system the clone should also be done the same way as `git clone` there is `--path`
 //    for different behavior

--- a/src/git/utils.rs
+++ b/src/git/utils.rs
@@ -38,10 +38,11 @@ pub fn clone_git_template_into_temp(
     tag: Option<&str>,
     revision: Option<&str>,
     identity: Option<&Path>,
+    skip_submodules: bool,
 ) -> anyhow::Result<(TempDir, String)> {
     let git_clone_dir = tmp_dir()?;
 
-    let builder = RepoCloneBuilder::new_with(git, branch, identity)?;
+    let builder = RepoCloneBuilder::new_with(git, branch, identity, skip_submodules)?;
 
     let repo = builder
         .clone_with_submodules(git_clone_dir.path())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,7 @@ fn get_source_template_into_temp(
                 git.tag(),
                 git.revision(),
                 git.identity(),
+                git.skip_submodules,
             )
             .map(|(dir, branch)| (dir, Some(branch)));
             if let Ok((ref temp_dir, _)) = result {

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -85,6 +85,7 @@ impl UserParsedInput {
                 args.template_path.revision(),
                 ssh_identity,
                 args.force_git_init,
+                args.skip_submodules,
             );
             return Self {
                 name: args.name.clone(),
@@ -161,6 +162,7 @@ impl UserParsedInput {
                         revision.as_ref(),
                         ssh_identity,
                         args.force_git_init,
+                        args.skip_submodules,
                     );
 
                     TemplateLocation::from(git_user_input)
@@ -231,6 +233,7 @@ impl UserParsedInput {
                 args.template_path.revision(),
                 ssh_identity,
                 args.force_git_init,
+                args.skip_submodules,
             );
             TemplateLocation::from(git_user_in)
         });
@@ -376,6 +379,7 @@ pub struct GitUserInput {
     revision: Option<String>,
     identity: Option<PathBuf>,
     _force_init: bool,
+    pub skip_submodules: bool,
 }
 
 impl GitUserInput {
@@ -386,6 +390,7 @@ impl GitUserInput {
         revision: Option<&impl AsRef<str>>,
         identity: Option<PathBuf>,
         force_init: bool,
+        skip_submodules: bool,
     ) -> Self {
         Self {
             url: url.as_ref().to_owned(),
@@ -394,6 +399,7 @@ impl GitUserInput {
             revision: revision.map(|s| s.as_ref().to_owned()),
             identity,
             _force_init: force_init,
+            skip_submodules,
         }
     }
 
@@ -406,6 +412,7 @@ impl GitUserInput {
             args.template_path.revision(),
             args.ssh_identity.clone(),
             args.force_git_init,
+            args.skip_submodules,
         )
     }
 

--- a/tests/integration/public_api.rs
+++ b/tests/integration/public_api.rs
@@ -40,6 +40,7 @@ fn it_allows_generate_call_with_public_args_and_returns_the_generated_path() {
         allow_commands: false,
         overwrite: false,
         other_args: None,
+        skip_submodules: false,
     };
 
     assert_eq!(


### PR DESCRIPTION
`cargo-generate` is typically used for generating templates from small repos. However, we would like to use it on [our repo] where the template lies in a larger mono-repo with git submodules that are not necessary to the template. The template is kept in this repo to failitate testing the various components within this repo. In this situation, the submodule download can add significat overhead to the initialization of the repo. Some have reported running our template generation command for tens of minutes and impacts the usability of our tool.

This change makes submodule cloning optional by adding a `--skip-submodules` flag that callers can set when using cargo-generate crate functions. This change intends the default behavior to clone submodules if they exist.

[our repo]: https://github.com/risc0/risc0

Fixes: #1111 