### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.20.0...HEAD)
+
+## [0.20.0] 2024-02-16
+
+[0.20.0]: https://github.com/cargo-generate/cargo-generate/compare/0.19.0...0.20.0
+
+### 🛠️  Maintenance
+
+- Bump home from 0.5.5 to 0.5.9 ([#1085](https://github.com/cargo-generate/cargo-generate/pull/1085))
+- Bump predicates from 3.0.4 to 3.1.0 ([#1103](https://github.com/cargo-generate/cargo-generate/pull/1103))
+- Bump assert_cmd from 2.0.12 to 2.0.13 ([#1102](https://github.com/cargo-generate/cargo-generate/pull/1102))
+- Bump bstr from 1.8.0 to 1.9.0 ([#1094](https://github.com/cargo-generate/cargo-generate/pull/1094))
+- Switch to sccache ([#1126](https://github.com/cargo-generate/cargo-generate/pull/1126))
+- Add Text and Editor type ([#1113](https://github.com/cargo-generate/cargo-generate/pull/1113))
+- Add --skip-submodules flag to optionalize cloning git submodules ([#1112](https://github.com/cargo-generate/cargo-generate/pull/1112))
+
+### 🤕 Fixes
+
+- Fix multiple `Unreleased` versions in CHANGELOG.md
+- Fix release pr should trigger builds
+- Fix very strange old lint ([#1125](https://github.com/cargo-generate/cargo-generate/pull/1125))
+- Release-plz config file breaking changes ([#1128](https://github.com/cargo-generate/cargo-generate/pull/1128))
+
 ## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.19.0...HEAD)
 
 ## [0.19.0] 2023-12-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 - Fix very strange old lint ([#1125](https://github.com/cargo-generate/cargo-generate/pull/1125))
 - Release-plz config file breaking changes ([#1128](https://github.com/cargo-generate/cargo-generate/pull/1128))
 
-## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.19.0...HEAD)
 
 ## [0.19.0] 2023-12-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-generate"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"


### PR DESCRIPTION
## 🤖 New release
* `cargo-generate`: 0.19.0 -> 0.20.0 (⚠️ API breaking changes)

### ⚠️ `cargo-generate` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GenerateArgs.skip_submodules in /tmp/.tmpL4VXQr/cargo-generate/src/args.rs:126
```

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).