### PR TITLE
chore: release v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.19.1...HEAD)
+
+## [0.19.1] 2024-03-26
+
+[0.19.1]: https://github.com/cargo-generate/cargo-generate/compare/0.19.0...0.19.1
+
+### ✨ Features
+
+- Add some more tests regarding conditionals see [#1119](https://github.com/cargo-generate/cargo-generate/pull/1119) ([#1133](https://github.com/cargo-generate/cargo-generate/pull/1133))
+
+### 📖 Documentation
+
+- Add docs about the new feature ([#1074](https://github.com/cargo-generate/cargo-generate/pull/1074)) ([#1132](https://github.com/cargo-generate/cargo-generate/pull/1132))
+
+### 🛠️  Maintenance
+
+- Bump home from 0.5.5 to 0.5.9 ([#1085](https://github.com/cargo-generate/cargo-generate/pull/1085))
+- Bump predicates from 3.0.4 to 3.1.0 ([#1103](https://github.com/cargo-generate/cargo-generate/pull/1103))
+- Bump assert_cmd from 2.0.12 to 2.0.13 ([#1102](https://github.com/cargo-generate/cargo-generate/pull/1102))
+- Bump bstr from 1.8.0 to 1.9.0 ([#1094](https://github.com/cargo-generate/cargo-generate/pull/1094))
+- Switch to sccache ([#1126](https://github.com/cargo-generate/cargo-generate/pull/1126))
+- Add Text and Editor type ([#1113](https://github.com/cargo-generate/cargo-generate/pull/1113))
+- Add --skip-submodules flag to optionalize cloning git submodules ([#1112](https://github.com/cargo-generate/cargo-generate/pull/1112))
+- Several versions ([#1130](https://github.com/cargo-generate/cargo-generate/pull/1130))
+- Ensure github-actions are updated by dependabot ([#1134](https://github.com/cargo-generate/cargo-generate/pull/1134))
+- Bump deps
+- Ignore dependabot on examples folder ([#1157](https://github.com/cargo-generate/cargo-generate/pull/1157))
+- Bump heck to 0.5 and gix-config to 0.36 ([#1160](https://github.com/cargo-generate/cargo-generate/pull/1160))
+
+### 🤕 Fixes
+
+- Fix multiple `Unreleased` versions in CHANGELOG.md
+- Fix release pr should trigger builds
+- Fix very strange old lint ([#1125](https://github.com/cargo-generate/cargo-generate/pull/1125))
+- Release-plz config file breaking changes ([#1128](https://github.com/cargo-generate/cargo-generate/pull/1128))
+- Default values are not ignored in silent mode ([#1153](https://github.com/cargo-generate/cargo-generate/pull/1153))
+
 ## Unreleased
 
 ## [0.19.0] 2023-12-13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-generate"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"

--- a/example-templates/text-placeholder2/Cargo.toml
+++ b/example-templates/text-placeholder2/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "placeholders"
+version = "0.1.0"
+edition = "2018"
+description = """{{description}}"""
+authors = [ "{{authors}}" ]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/example-templates/text-placeholder2/cargo-generate.toml
+++ b/example-templates/text-placeholder2/cargo-generate.toml
@@ -1,0 +1,17 @@
+[template]
+cargo_generate_version = ">=0.9.0"
+
+[placeholders]
+description = { type="text", prompt="Long description for the crate?" }
+ask_for_string = { type="bool", prompt="Make a choice too?", default=true }
+
+[conditional.'ask_for_string'.placeholders.choice]
+type = "string"
+prompt = "Please select one..."
+choices = ["One", "Two", "Three", "Four"]
+
+[conditional.'{ choice == "One" }'.placeholders.styling]
+type = "string"
+prompt = "How do you want to create CSS?"
+choices = ["Tailwind", "Vanilla"]
+default = "Vanilla"

--- a/example-templates/text-placeholder2/src/main.rs
+++ b/example-templates/text-placeholder2/src/main.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!("Hello, {{authors}}!");
+    println!("The boolean was: {{some_bool}}");
+    println!("Your choice was: {{choice}}");
+    println!("Your styling was: {{styling}}");
+}


### PR DESCRIPTION
## 🤖 New release
* `cargo-generate`: 0.19.0 -> 0.19.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).