### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 
 - Release plz can now force push
 
-## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.20.0...HEAD)
 
 ## [0.20.0] 2024-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.21.0...HEAD)
+
+## [0.21.0] 2024-04-10
+
+[0.21.0]: https://github.com/cargo-generate/cargo-generate/compare/0.20.0...0.21.0
+
+### ✨ Features
+
+- Add the cargo-binstall installation method
+- Don't rename snake_case to hyphens in project name ([#1172](https://github.com/cargo-generate/cargo-generate/pull/1172))
+
+### 🛠️  Maintenance
+
+- Small reformatting only
+
+### 🤕 Fixes
+
+- Release plz can now force push
+
 ## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.20.0...HEAD)
 
 ## [0.20.0] 2024-03-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-generate"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"


### PR DESCRIPTION
## 🤖 New release
* `cargo-generate`: 0.20.0 -> 0.21.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).