### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.20.1...HEAD)
+
 ## [0.21.0] 2024-05-02
 
-[0.21.0]: <REPO>/compare/0.20.0...0.21.0
+[0.21.0]: https://github.com/cargo-generate/cargo-generate/compare/0.20.0...0.21.0
 
 ### ✨ Features
 
@@ -25,10 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release plz can now force push
 - Very minor markdown fix ([#1166](https://github.com/cargo-generate/cargo-generate/pull/1166))
 - Fix changelog creation config file, regarding the unreleased section
-
-# Changelog
-
-## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.20.0...HEAD)
 
 ## [0.20.0] 2024-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.21.0] 2024-05-02
+
+[0.21.0]: <REPO>/compare/0.20.0...0.21.0
+
+### ✨ Features
+
+- Add the cargo-binstall installation method
+- Don't rename snake_case to hyphens in project name ([#1172](https://github.com/cargo-generate/cargo-generate/pull/1172))
+
+### 🛠️ Maintenance
+
+- Small reformatting only
+- Enable the sponsor button
+- Update locked dependencies + bump rhai from 1.17.1 to 1.18.0 ([#1182](https://github.com/cargo-generate/cargo-generate/pull/1182))
+
+### 🤕 Fixes
+
+- Release plz can now force push
+- Very minor markdown fix ([#1166](https://github.com/cargo-generate/cargo-generate/pull/1166))
+- Fix changelog creation config file, regarding the unreleased section
+
+# Changelog
+
 ## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.20.0...HEAD)
 
 ## [0.20.0] 2024-03-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-generate"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"


### PR DESCRIPTION
## 🤖 New release
* `cargo-generate`: 0.20.0 -> 0.21.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.21.0] 2024-05-02

[0.21.0]: <REPO>/compare/0.20.0...0.21.0

### ✨ Features

- Add the cargo-binstall installation method
- Don't rename snake_case to hyphens in project name ([#1172](https://github.com/cargo-generate/cargo-generate/pull/1172))

### 🛠️ Maintenance

- Small reformatting only
- Enable the sponsor button
- Update locked dependencies + bump rhai from 1.17.1 to 1.18.0 ([#1182](https://github.com/cargo-generate/cargo-generate/pull/1182))

### 🤕 Fixes

- Release plz can now force push
- Very minor markdown fix ([#1166](https://github.com/cargo-generate/cargo-generate/pull/1166))
- Fix changelog creation config file, regarding the unreleased section
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).