### PR TITLE
feat(rhai-hooks): add a date API that provides year, month and day access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror",
+ "time",
  "toml",
  "url",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ walkdir = "~2.5"
 remove_dir_all = "~0.8"
 ignore = "~0.4"
 anyhow = "~1.0"
+time = "~0.3"
 toml = { version = "~0.8", features = ["preserve_order"] }
 thiserror = "~1.0"
 home = "~0.5"

--- a/guide/src/templates/scripting.rhai-extensions.md
+++ b/guide/src/templates/scripting.rhai-extensions.md
@@ -62,6 +62,26 @@ Besides the basic [`Rhai`] features, these are the modules/behaviors defined:
 
   Create/overwrite a file inside the template folder, each entry in the array on a new line
 
+### System
+
+* **`system::command(cmd: &str, args: Array) -> value`**
+
+  Execute a command on the system generating the project from a template.
+
+  The user will be prompted with 
+
+  ```
+  The template is requesting to run the following command. Do you agree?
+  <command> <args>
+  ```
+
+  unless the user uses the flag `--allow-commands`. If the user attempts to use the
+  `--silent` flag without the `--allow-commands` flag will fail.
+
+* **`system::date() -> Date`**
+  
+  Get the date in UTC from the system as an object with the properties `year`, `month`, and `day`.
+
 ### Other
 
 * **`abort(reason: &str)`**: Aborts `cargo-generate` with a script error.


### PR DESCRIPTION
Most license files start with a copyright statement with a year but `cargo-generate` hooks or template parameters do not provide access to that information . The only alternatives would be using the `system::command` API but that isn't something that is very portable and prompting the user for the year which is less than ideal. This PR adds a new API `system::date` which returns an object with 3 properties, `year`, `month`, `day`. This would allow for generating a license from a rhai hook:

```rhai
file::write(license.txt, `Copyright ${system::date().year} ${authors}
...
`);

```

I've also added docs for the `system` module, though I don't know if they cover the details outlined in #616.