### PR TITLE
fix: actually set `--depth 1`

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -110,6 +110,7 @@ impl<'cb> RepoCloneBuilder<'cb> {
         let mut fetch_options = FetchOptions::new();
         fetch_options.proxy_options(proxy_options);
         fetch_options.remote_callbacks(callbacks);
+        fetch_options.depth(1);
 
         let mut builder = self.builder;
         builder.fetch_options(fetch_options);


### PR DESCRIPTION
On large repos cargo-generate takes several minutes to run. This lowers that to... a dozen or so seconds, which is still pretty bad