### PR TITLE
chore: release v0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.2] 2024-07-05
+
+[0.21.2]: <REPO>/compare/0.21.1...0.21.2
+
+### 🤕 Fixes
+
+- Actually set `--depth 1` ([#1211](https://github.com/cargo-generate/cargo-generate/pull/1211))
+
 ## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.21.1...HEAD)
 
 ## [0.21.1] 2024-06-21

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-generate"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.21.1"
+version = "0.21.2"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"


### PR DESCRIPTION
## 🤖 New release
* `cargo-generate`: 0.21.1 -> 0.21.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.21.2] 2024-07-05

[0.21.2]: <REPO>/compare/0.21.1...0.21.2

### 🤕 Fixes

- Actually set `--depth 1` ([#1211](https://github.com/cargo-generate/cargo-generate/pull/1211))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).