### PR TITLE
chore: release v0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.21.2] 2024-07-09
+## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.21.2...HEAD)
 
-[0.21.2]: <REPO>/compare/0.21.1...0.21.2
+## [0.21.2] 2024-07-10
+
+[0.21.2]: https://github.com/cargo-generate/cargo-generate/compare/0.21.1...0.21.2
 
 ### 🛠️ Maintenance
 
@@ -16,8 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🤕 Fixes
 
 - Actually set `--depth 1` ([#1211](https://github.com/cargo-generate/cargo-generate/pull/1211))
-
-## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.21.1...HEAD)
 
 ## [0.21.1] 2024-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.2] 2024-07-09
+
+[0.21.2]: <REPO>/compare/0.21.1...0.21.2
+
+### 🛠️ Maintenance
+
+- Bump git2 from 0.18.3 to 0.19.0 ([#1212](https://github.com/cargo-generate/cargo-generate/pull/1212))
+
+### 🤕 Fixes
+
+- Actually set `--depth 1` ([#1211](https://github.com/cargo-generate/cargo-generate/pull/1211))
+
 ## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.21.1...HEAD)
 
 ## [0.21.1] 2024-06-21

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-generate"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.21.1"
+version = "0.21.2"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"

--- a/cliff.toml
+++ b/cliff.toml
@@ -14,7 +14,7 @@ body = """
 {% if version -%}\
     ## [{{ version | trim_start_matches(pat="v") }}] {{ timestamp | date(format="%Y-%m-%d") }}
 
-    [{{ version | trim_start_matches(pat="v") }}]: <REPO>/compare/{{ previous.version }}...{{ version }}
+    [{{ version | trim_start_matches(pat="v") }}]: https://github.com/cargo-generate/cargo-generate/compare/{{ previous.version }}...{{ version }}
 {% else -%}
     ## [Unreleased](<REPO>/compare/{{ previous.version }}...HEAD)
 {% endif -%}


### PR DESCRIPTION
## 🤖 New release
* `cargo-generate`: 0.21.1 -> 0.21.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.21.2] 2024-07-09

[0.21.2]: <REPO>/compare/0.21.1...0.21.2

### 🛠️ Maintenance

- Bump git2 from 0.18.3 to 0.19.0 ([#1212](https://github.com/cargo-generate/cargo-generate/pull/1212))

### 🤕 Fixes

- Actually set `--depth 1` ([#1211](https://github.com/cargo-generate/cargo-generate/pull/1211))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).