### PR TITLE
feat: reformat help text in the style of cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
 name = "cargo-generate"
 version = "0.21.2"
 dependencies = [
+ "anstyle",
  "anyhow",
  "assert_cmd",
  "auth-git2",
@@ -246,8 +247,11 @@ version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1670,6 +1674,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1710,16 @@ checksum = "572818b3472910acbd5dff46a3413715c18e934b071ab2ba464a7b2c2af16376"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,7 @@ include = ["src/**/*", "LICENSE-*", "*.md"]
 anstyle = "1.0.7"
 anyhow = "~1.0"
 auth-git2 = "~0.5"
-clap = { version = "~4.5", default-features = true, features = [
-    "derive",
-    "std",
-    "help",
-    "wrap_help",
-] }
+clap = { version = "~4.5", features = ["derive", "wrap_help"] }
 console = "~0.15"
 dialoguer = "~0.11"
 env_logger = "~0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,58 +9,54 @@ edition = "2021"
 include = ["src/**/*", "LICENSE-*", "*.md"]
 
 [dependencies]
-clap = { version = "~4.5", features = ["derive", "std", "help"], default-features = false }
-git2 = { version = "~0.19", features = ["ssh", "https"], default-features = false }
+anyhow = "~1.0"
 auth-git2 = "~0.5"
+clap = { version = "~4.5", default-features = false, features = [
+    "derive",
+    "std",
+    "help",
+] }
 console = "~0.15"
 dialoguer = "~0.11"
-indicatif = "~0.17"
-tempfile = "~3.10"
-regex = "~1.10"
-heck = "~0.5"
-walkdir = "~2.5"
-remove_dir_all = "~0.8"
-ignore = "~0.4"
-anyhow = "~1.0"
-time = "~0.3"
-toml = { version = "~0.8", features = ["preserve_order"] }
-thiserror = "~1.0"
-home = "~0.5"
-sanitize-filename = "~0.5"
-rhai = "~1.19"
-path-absolutize = "~3.1"
-gix-config = "~0.37"
-paste = "~1.0"
-names = { version = "~0.14", default-features = false }
-log = "~0.4"
 env_logger = "~0.11"
-indexmap = { version = "~2", features = ["serde"] }
 fs-err = "2.11"
-
-# liquid
+git2 = { version = "~0.19", default-features = false, features = [
+    "ssh",
+    "https",
+] }
+gix-config = "~0.37"
+heck = "~0.5"
+home = "~0.5"
+ignore = "~0.4"
+indexmap = { version = "~2", features = ["serde"] }
+indicatif = "~0.17"
 liquid = "~0.26"
 liquid-core = "~0.26"
-liquid-lib = "~0.26"
 liquid-derive = "~0.26"
-
-[dependencies.openssl]
-version = "~0.10"
-optional = true
-
-[dependencies.semver]
-version = "~1.0"
-features = ["serde"]
-
-[dependencies.serde]
-version = "~1.0"
-features = ["derive"]
+liquid-lib = "~0.26"
+log = "~0.4"
+names = { version = "~0.14", default-features = false }
+openssl = { version = "~0.10", optional = true }
+paste = "~1.0"
+path-absolutize = "~3.1"
+regex = "~1.10"
+remove_dir_all = "~0.8"
+rhai = "~1.19"
+sanitize-filename = "~0.5"
+semver = { version = "~1.0", features = ["serde"] }
+serde = { version = "~1.0", features = ["derive"] }
+tempfile = "~3.10"
+thiserror = "~1.0"
+time = "~0.3"
+toml = { version = "~0.8", features = ["preserve_order"] }
+walkdir = "~2.5"
 
 [dev-dependencies]
-predicates = "~3.1"
 assert_cmd = "~2.0"
-indoc = "~2.0"
-url = "~2.5"
 bstr = "~1.9"
+indoc = "~2.0"
+predicates = "~3.1"
+url = "~2.5"
 
 [features]
 default = ["vendored-libgit2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,14 @@ edition = "2021"
 include = ["src/**/*", "LICENSE-*", "*.md"]
 
 [dependencies]
+anstyle = "1.0.7"
 anyhow = "~1.0"
 auth-git2 = "~0.5"
-clap = { version = "~4.5", default-features = false, features = [
+clap = { version = "~4.5", default-features = true, features = [
     "derive",
     "std",
     "help",
+    "wrap_help",
 ] }
 console = "~0.15"
 dialoguer = "~0.11"

--- a/src/args.rs
+++ b/src/args.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 use crate::git;
 
-/// Styles from https://github.com/rust-lang/cargo/blob/master/src/cargo/util/style.rs
+/// Styles from <https://github.com/rust-lang/cargo/blob/master/src/cargo/util/style.rs>
 mod style {
     use anstyle::*;
     use clap::builder::Styles;

--- a/src/args.rs
+++ b/src/args.rs
@@ -9,13 +9,47 @@ use serde::Deserialize;
 
 use crate::git;
 
+/// Styles from https://github.com/rust-lang/cargo/blob/master/src/cargo/util/style.rs
+mod style {
+    use anstyle::*;
+    use clap::builder::Styles;
+
+    const HEADER: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
+    const USAGE: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
+    const LITERAL: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+    const PLACEHOLDER: Style = AnsiColor::Cyan.on_default();
+    const ERROR: Style = AnsiColor::Red.on_default().effects(Effects::BOLD);
+    const VALID: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+    const INVALID: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
+
+    pub const STYLES: Styles = {
+        Styles::styled()
+            .header(HEADER)
+            .usage(USAGE)
+            .literal(LITERAL)
+            .placeholder(PLACEHOLDER)
+            .error(ERROR)
+            .valid(VALID)
+            .invalid(INVALID)
+            .error(ERROR)
+    };
+}
+
+mod heading {
+    pub const GIT_PARAMETERS: &str = "Git Parameters";
+    pub const TEMPLATE_SELECTION: &str = "Template Selection";
+    pub const OUTPUT_PARAMETERS: &str = "Output Parameters";
+}
+
 #[derive(Parser)]
 #[command(
     name = "cargo generate",
     bin_name = "cargo",
     arg_required_else_help(true),
     version,
-    about
+    about,
+    next_line_help(false),
+    styles(style::STYLES)
 )]
 pub enum Cli {
     #[command(name = "generate", visible_alias = "gen")]
@@ -52,77 +86,78 @@ pub struct GenerateArgs {
 
     /// Directory to create / project name; if the name isn't in kebab-case, it will be converted
     /// to kebab-case unless `--force` is given.
-    #[arg(long, short, value_parser)]
+    #[arg(long, short, value_parser, help_heading = heading::OUTPUT_PARAMETERS)]
     pub name: Option<String>,
 
-    /// Don't convert the project name to kebab-case before creating the directory.
-    /// Note that cargo generate won't overwrite an existing directory, even if `--force` is given.
-    #[arg(long, short, action)]
+    /// Don't convert the project name to kebab-case before creating the directory. Note that cargo
+    /// generate won't overwrite an existing directory, even if `--force` is given.
+    #[arg(long, short, action, help_heading = heading::OUTPUT_PARAMETERS)]
     pub force: bool,
 
     /// Enables more verbose output.
     #[arg(long, short, action)]
     pub verbose: bool,
 
-    /// Pass template values through a file
-    /// Values should be in the format `key=value`, one per line
-    #[arg(long, value_parser)]
+    /// Pass template values through a file. Values should be in the format `key=value`, one per
+    /// line
+    #[arg(long="values-file", value_parser, alias="template-values-file", value_name="FILE", help_heading = heading::OUTPUT_PARAMETERS)]
     pub template_values_file: Option<String>,
 
-    /// If silent mode is set all variables will be
-    /// extracted from the template_values_file.
-    /// If a value is missing the project generation will fail
+    /// If silent mode is set all variables will be extracted from the template_values_file. If a
+    /// value is missing the project generation will fail
     #[arg(long, short, requires("name"), action)]
     pub silent: bool,
 
-    /// Use specific configuration file. Defaults to $CARGO_HOME/cargo-generate or $HOME/.cargo/cargo-generate
+    /// Use specific configuration file. Defaults to $CARGO_HOME/cargo-generate or
+    /// $HOME/.cargo/cargo-generate
     #[arg(short, long, value_parser)]
     pub config: Option<PathBuf>,
 
     /// Specify the VCS used to initialize the generated template.
-    #[arg(long, value_parser)]
+    #[arg(long, value_parser, help_heading = heading::OUTPUT_PARAMETERS)]
     pub vcs: Option<Vcs>,
 
     /// Populates template variable `crate_type` with value `"lib"`
-    #[arg(long, conflicts_with = "bin", action)]
+    #[arg(long, conflicts_with = "bin", action, help_heading = heading::OUTPUT_PARAMETERS)]
     pub lib: bool,
 
     /// Populates a template variable `crate_type` with value `"bin"`
-    #[arg(long, conflicts_with = "lib", action)]
+    #[arg(long, conflicts_with = "lib", action, help_heading = heading::OUTPUT_PARAMETERS)]
     pub bin: bool,
 
     /// Use a different ssh identity
-    #[arg(short = 'i', long = "identity", value_parser)]
+    #[arg(short = 'i', long = "identity", value_parser, value_name="IDENTITY", help_heading = heading::GIT_PARAMETERS)]
     pub ssh_identity: Option<PathBuf>,
 
     /// Define a value for use during template expansion. E.g `--define foo=bar`
-    #[arg(long, short, number_of_values = 1, value_parser)]
+    #[arg(long, short, number_of_values = 1, value_parser, help_heading = heading::OUTPUT_PARAMETERS)]
     pub define: Vec<String>,
 
-    /// Generate the template directly into the current dir. No subfolder will be created and no vcs is initialized.
-    #[arg(long, action)]
+    /// Generate the template directly into the current dir. No subfolder will be created and no vcs
+    /// is initialized.
+    #[arg(long, action, help_heading = heading::OUTPUT_PARAMETERS)]
     pub init: bool,
 
     /// Generate the template directly at the given path.
-    #[arg(long, value_parser)]
+    #[arg(long, value_parser, value_name="PATH", help_heading = heading::OUTPUT_PARAMETERS)]
     pub destination: Option<PathBuf>,
 
     /// Will enforce a fresh git init on the generated project
-    #[arg(long, action)]
+    #[arg(long, action, help_heading = heading::OUTPUT_PARAMETERS)]
     pub force_git_init: bool,
 
-    /// Allows running system commands without being prompted.
-    /// Warning: Setting this flag will enable the template to run arbitrary system commands without user confirmation.
-    /// Use at your own risk and be sure to review the template code beforehand.
-    #[arg(short, long, action)]
+    /// Allows running system commands without being prompted. Warning: Setting this flag will
+    /// enable the template to run arbitrary system commands without user confirmation. Use at your
+    /// own risk and be sure to review the template code beforehand.
+    #[arg(short, long, action, help_heading = heading::OUTPUT_PARAMETERS)]
     pub allow_commands: bool,
 
     /// Allow the template to overwrite existing files in the destination.
-    #[arg(short, long, action)]
+    #[arg(short, long, action, help_heading = heading::OUTPUT_PARAMETERS)]
     pub overwrite: bool,
 
     /// Skip downloading git submodules (if there are any)
-    #[arg(long, action)]
+    #[arg(long, action, help_heading = heading::GIT_PARAMETERS)]
     pub skip_submodules: bool,
 
     /// All args after "--" on the command line.
@@ -159,18 +194,20 @@ impl Default for GenerateArgs {
 
 #[derive(Default, Debug, Clone, Args)]
 pub struct TemplatePath {
-    /// Auto attempt to use as either `--git` or `--favorite`.
-    /// If either is specified explicitly, use as subfolder.
+    /// Auto attempt to use as either `--git` or `--favorite`. If either is specified explicitly,
+    /// use as subfolder.
     #[arg(required_unless_present_any(&["SpecificPath"]))]
     pub auto_path: Option<String>,
 
-    /// Specifies a subfolder within the template repository to be used as the actual template.
+    /// Specifies the subfolder within the template repository to be used as the actual template.
     #[arg()]
     pub subfolder: Option<String>,
 
-    /// Expand $CWD as a template, then run `cargo test` on the expansion (set $CARGO_GENERATE_TEST_CMD to override test command).
+    /// Expand $CWD as a template, then run `cargo test` on the expansion (set
+    /// $CARGO_GENERATE_TEST_CMD to override test command).
     ///
-    /// Any arguments given after the `--test` argument, will be used as arguments for the test command.
+    /// Any arguments given after the `--test` argument, will be used as arguments for the test
+    /// command.
     #[arg(long, action, group("SpecificPath"))]
     pub test: bool,
 
@@ -180,28 +217,28 @@ pub struct TemplatePath {
     ///
     /// Note that cargo generate will first attempt to interpret the `owner/repo` form as a
     /// relative path and only try a GitHub URL if the local path doesn't exist.
-    #[arg(short, long, group("SpecificPath"))]
+    #[arg(short, long, group("SpecificPath"), help_heading = heading::TEMPLATE_SELECTION)]
     pub git: Option<String>,
 
     /// Branch to use when installing from git
-    #[arg(short, long, conflicts_with_all = ["revision", "tag"])]
+    #[arg(short, long, conflicts_with_all = ["revision", "tag"], help_heading = heading::GIT_PARAMETERS)]
     pub branch: Option<String>,
 
     /// Tag to use when installing from git
-    #[arg(short, long, conflicts_with_all = ["revision", "branch"])]
+    #[arg(short, long, conflicts_with_all = ["revision", "branch"], help_heading = heading::GIT_PARAMETERS)]
     pub tag: Option<String>,
 
     /// Git revision to use when installing from git (e.g. a commit hash)
-    #[arg(short, long, conflicts_with_all = ["tag", "branch"], alias = "rev")]
+    #[arg(short, long, conflicts_with_all = ["tag", "branch"], alias = "rev", help_heading = heading::GIT_PARAMETERS)]
     pub revision: Option<String>,
 
     /// Local path to copy the template from. Can not be specified together with --git.
-    #[arg(short, long, group("SpecificPath"))]
+    #[arg(short, long, group("SpecificPath"), help_heading = heading::TEMPLATE_SELECTION)]
     pub path: Option<String>,
 
     /// Generate a favorite template as defined in the config. In case the favorite is undefined,
     /// use in place of the `--git` option, otherwise specifies the subfolder
-    #[arg(long, group("SpecificPath"))]
+    #[arg(long, group("SpecificPath"), help_heading = heading::TEMPLATE_SELECTION)]
     pub favorite: Option<String>,
 }
 


### PR DESCRIPTION
My motivation here was that when I run cargo generate, I find it difficult to find the options that are useful as there's no real order to the help output. This helps by injecting color, sorting the options into some reasonable sections, and shortening the longest option name.

# Before:

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/82b7498d-cda3-4096-8f57-4e92f240e543">
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/e6caaedd-7da2-4b94-bd67-dda42e5d41f3">


# After:

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/fcd6f4ca-3380-4720-87eb-da5d515c1042">
