### PR TITLE
chore: release v0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.3] 2024-07-15
+
+[0.21.3]: https://github.com/cargo-generate/cargo-generate/compare/0.21.2...0.21.3
+
+### ✨ Features
+
+- Reformat help text in the style of cargo ([#1223](https://github.com/cargo-generate/cargo-generate/pull/1223))
+
+### 🛠️ Maintenance
+
+- Cancel in progres CI jobs when on the same run ([#1227](https://github.com/cargo-generate/cargo-generate/pull/1227))
+
+### 🤕 Fixes
+
+- Tag option, see [#1222](https://github.com/cargo-generate/cargo-generate/pull/1222) ([#1226](https://github.com/cargo-generate/cargo-generate/pull/1226))
+
 ## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.21.2...HEAD)
 
 ## [0.21.2] 2024-07-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.21.3...HEAD)
+
 ## [0.21.3] 2024-07-15
 
 [0.21.3]: https://github.com/cargo-generate/cargo-generate/compare/0.21.2...0.21.3
@@ -21,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tag option, see [#1222](https://github.com/cargo-generate/cargo-generate/pull/1222) ([#1226](https://github.com/cargo-generate/cargo-generate/pull/1226))
 
-## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.21.2...HEAD)
 
 ## [0.21.2] 2024-07-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-generate"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.21.2"
+version = "0.21.3"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"


### PR DESCRIPTION
## 🤖 New release
* `cargo-generate`: 0.21.2 -> 0.21.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.21.3] 2024-07-15

[0.21.3]: https://github.com/cargo-generate/cargo-generate/compare/0.21.2...0.21.3

### ✨ Features

- Reformat help text in the style of cargo ([#1223](https://github.com/cargo-generate/cargo-generate/pull/1223))

### 🛠️ Maintenance

- Cancel in progres CI jobs when on the same run ([#1227](https://github.com/cargo-generate/cargo-generate/pull/1227))

### 🤕 Fixes

- Tag option, see [#1222](https://github.com/cargo-generate/cargo-generate/pull/1222) ([#1226](https://github.com/cargo-generate/cargo-generate/pull/1226))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).