### PR TITLE
chore: release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.22.0...HEAD)
+
 ## [0.22.0] 2024-09-01
 
 [0.22.0]: https://github.com/cargo-generate/cargo-generate/compare/0.21.3...0.22.0
@@ -18,8 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🤕 Fixes
 
 - Fix gitconfig `insteadOf` ([#874](https://github.com/cargo-generate/cargo-generate/pull/874)) ([#1265](https://github.com/cargo-generate/cargo-generate/pull/1265))
-
-## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.21.3...HEAD)
 
 ## [0.21.3] 2024-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] 2024-09-01
+
+[0.22.0]: https://github.com/cargo-generate/cargo-generate/compare/0.21.3...0.22.0
+
+### 📖 Documentation
+
+- Update 'use_git' example ([#1191](https://github.com/cargo-generate/cargo-generate/pull/1191))
+- Refine the docs so that the usage guide provides easier access to the ssh related docs
+- Fix links and small adjustments
+
+### 🤕 Fixes
+
+- Fix gitconfig `insteadOf` ([#874](https://github.com/cargo-generate/cargo-generate/pull/874)) ([#1265](https://github.com/cargo-generate/cargo-generate/pull/1265))
+
 ## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.21.3...HEAD)
 
 ## [0.21.3] 2024-07-15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo-generate"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.21.3"
+version = "0.22.0"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"


### PR DESCRIPTION
## 🤖 New release
* `cargo-generate`: 0.21.3 -> 0.22.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.22.0] 2024-09-01

[0.22.0]: https://github.com/cargo-generate/cargo-generate/compare/0.21.3...0.22.0

### 📖 Documentation

- Update 'use_git' example ([#1191](https://github.com/cargo-generate/cargo-generate/pull/1191))
- Refine the docs so that the usage guide provides easier access to the ssh related docs
- Fix links and small adjustments

### 🤕 Fixes

- Fix gitconfig `insteadOf` ([#874](https://github.com/cargo-generate/cargo-generate/pull/874)) ([#1265](https://github.com/cargo-generate/cargo-generate/pull/1265))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).