### PR TITLE
chore(deps): don't request ineffective ssh_key_from_memory feature from git2-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "LICENSE-*", "*.md"]
 
 [dependencies.git2]
 default-features = false
-features = ["ssh", "https", "ssh_key_from_memory"]
+features = ["ssh", "https"]
 version = "~0.19"
 
 [dependencies]


### PR DESCRIPTION
The ssh_key_from_memory feature has had no effect in the last 6 years. It will be removed in the next major release (https://github.com/rust-lang/git2-rs/pull/1087) and it will thus be an error to request it.