### PR TITLE
chore: release v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.1] 2024-10-04
+
+[0.22.1]: https://github.com/cargo-generate/cargo-generate/compare/0.22.0...0.22.1
+
+### ✨ Features
+
+- Run e2e tests with git over ssh only on non PRs, for secret access reasons ([#1287](https://github.com/cargo-generate/cargo-generate/pull/1287))
+
+### 🛠️ Maintenance
+
+- Bump tempfile from 3.10.1 to 3.13.0 ([#1281](https://github.com/cargo-generate/cargo-generate/pull/1281))
+
+### 🤕 Fixes
+
+- Fix lint that wants a const fn ([#1285](https://github.com/cargo-generate/cargo-generate/pull/1285))
+
 ## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.22.0...HEAD)
 
 ## [0.22.0] 2024-09-01

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo-generate"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"


### PR DESCRIPTION
## 🤖 New release
* `cargo-generate`: 0.22.0 -> 0.22.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.22.1] 2024-10-04

[0.22.1]: https://github.com/cargo-generate/cargo-generate/compare/0.22.0...0.22.1

### ✨ Features

- Run e2e tests with git over ssh only on non PRs, for secret access reasons ([#1287](https://github.com/cargo-generate/cargo-generate/pull/1287))

### 🛠️ Maintenance

- Bump tempfile from 3.10.1 to 3.13.0 ([#1281](https://github.com/cargo-generate/cargo-generate/pull/1281))

### 🤕 Fixes

- Fix lint that wants a const fn ([#1285](https://github.com/cargo-generate/cargo-generate/pull/1285))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).