### PR TITLE
chore: release v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix lint that wants a const fn (#1285)
 - Fix tests and copy path simplifiation ([#1346](https://github.com/cargo-generate/cargo-generate/pull/1346))
 
-## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.22.0...HEAD)
 
 ## [0.22.0] 2024-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.1] 2024-12-27
+
+[0.22.1]: https://github.com/cargo-generate/cargo-generate/compare/0.22.0...0.22.1
+
+### ✨ Features
+
+- Run e2e tests with git over ssh only on non PRs, for secret access reasons (#1287)
+- Identify workspace project at parent folder and add as a member (#1342)
+
+### 🛠️ Maintenance
+
+- Bump tempfile from 3.10.1 to 3.13.0 (#1281)
+- Bump auth-git2 from 0.5.4 to 0.5.5 (#1277)
+- Bump bstr from 1.9.1 to 1.10.0 (#1262)
+- Clarify `.liquid` overwrite and ignore behavior ([#1295](https://github.com/cargo-generate/cargo-generate/pull/1295))
+- Bump indexmap from 2.5.0 to 2.6.0 (#1297)
+
+### 🤕 Fixes
+
+- Fix lint that wants a const fn (#1285)
+- Fix tests and copy path simplifiation ([#1346](https://github.com/cargo-generate/cargo-generate/pull/1346))
+
 ## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/0.22.0...HEAD)
 
 ## [0.22.0] 2024-09-01

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo-generate"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"


### PR DESCRIPTION
## 🤖 New release
* `cargo-generate`: 0.22.0 -> 0.22.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.22.1] 2024-12-27

[0.22.1]: https://github.com/cargo-generate/cargo-generate/compare/0.22.0...0.22.1

### ✨ Features

- Run e2e tests with git over ssh only on non PRs, for secret access reasons (#1287)
- Identify workspace project at parent folder and add as a member (#1342)

### 🛠️ Maintenance

- Bump tempfile from 3.10.1 to 3.13.0 (#1281)
- Bump auth-git2 from 0.5.4 to 0.5.5 (#1277)
- Bump bstr from 1.9.1 to 1.10.0 (#1262)
- Clarify `.liquid` overwrite and ignore behavior ([#1295](https://github.com/cargo-generate/cargo-generate/pull/1295))
- Bump indexmap from 2.5.0 to 2.6.0 (#1297)

### 🤕 Fixes

- Fix lint that wants a const fn (#1285)
- Fix tests and copy path simplifiation ([#1346](https://github.com/cargo-generate/cargo-generate/pull/1346))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).