### PR TITLE
feat(errors): fail on template errors

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -95,8 +95,23 @@ pub struct GenerateArgs {
     pub force: bool,
 
     /// Enables more verbose output.
-    #[arg(long, short, action)]
+    #[arg(long, short, action, conflicts_with = "quiet")]
     pub verbose: bool,
+
+    /// Opposite of verbose, suppresses errors & warning in output
+    /// Conflicts with verbose, and requires the use of --continue-on-error
+    #[arg(
+        long,
+        short,
+        action,
+        conflicts_with = "verbose",
+        requires = "continue_on_error"
+    )]
+    pub quiet: bool,
+
+    /// Continue if errors in templates are encountered
+    #[arg(long, action)]
+    pub continue_on_error: bool,
 
     /// Pass template values through a file. Values should be in the format `key=value`, one per
     /// line
@@ -177,6 +192,8 @@ impl Default for GenerateArgs {
             name: None,
             force: false,
             verbose: false,
+            quiet: false,
+            continue_on_error: false,
             template_values_file: None,
             silent: false,
             config: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,7 +512,7 @@ fn expand_template(
         user_parsed_input.silent(),
         rhai_filter_files.clone(),
     );
-    template::walk_dir(
+    let result = template::walk_dir(
         &mut template_config,
         template_dir,
         &all_hook_files,
@@ -520,8 +520,21 @@ fn expand_template(
         rhai_engine,
         &rhai_filter_files,
         &mut pbar,
-        args.verbose,
-    )?;
+        args.quiet,
+    );
+
+    match result {
+        Ok(()) => (),
+        Err(e) => {
+            // Don't print the error twice
+            if !args.quiet && args.continue_on_error {
+                warn!("{}", e);
+            }
+            if !args.continue_on_error {
+                return Err(e);
+            }
+        }
+    };
 
     // run post-hooks
     execute_hooks(

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -878,6 +878,7 @@ version = "0.1.0"
         .arg_git(template.path())
         .arg_name("foobar-project")
         .arg_branch("main")
+        .arg("--continue-on-error")
         .current_dir(dir.path())
         .assert()
         .success()

--- a/tests/integration/public_api.rs
+++ b/tests/integration/public_api.rs
@@ -28,6 +28,8 @@ fn it_allows_generate_call_with_public_args_and_returns_the_generated_path() {
         verbose: true,
         template_values_file: None,
         silent: false,
+        continue_on_error: false,
+        quiet: false,
         list_favorites: false,
         config: None,
         bin: true,


### PR DESCRIPTION
Fixes #1339 

So I'm aware we didn't agree on a design/solution for the linked issue before I started, so I'm happy to change the approach. My reasoning for the approach taken:

- I personally think that fatal errors such as a template containing syntax errors (since any non-trivial template is very unlikely to be a usable rust file) should not be hidden behind a `--verbose` flag (though admittedly I should have used that one when I ran into this issue myself, that's my bad).
- because expanded templates are unlikely to be valid rust, we should always error on invalid templates, but I am aware that this is a breaking change, and is also rather opinionated, so I can see not wanting this. 

So I've tried to strike a happy medium by:

- leaving `--verbose` alone, I wasn't  sure if it was used anywhere else
- introducing `--continue-on-error` and `--quiet` to maintain previous behaviour if users want to (though it is opt in)
- unless `--continue-on-error` is given, we exit unsuccessfully on a template syntax error, although we do still walk the entire tree, so all errors should get displayed
- I switched to reporting which files contained the errors from absolute to relative, since the absolute path is in a tmp dir for me which makes it harder to figure out which template file I need to go and edit. I think this is a nice UX improvement. 

This aligns things more with what I would have expected from the CLI options. One thing left to resolve would be that if this were merged we'd have `--quiet` and `--silent` which would be about quite different things, but I didn't touch that because I thought that was outside the scope of this PR. I'm happy to include any changes on this though if we can come up with better names. 