### PR TITLE
fix(ci): fix that checks on release pr where not triggered

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ on:
     branches: [main]
   workflow_call:
   merge_group:
+  repository_dispatch:
+    types: [create-pull-request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
The issue is explained here: https://github.com/orgs/community/discussions/65321

In essence creating a pr from a workflow run with the gh token will not trigger the pull_request created event. 

The idea is to listen to an event that is also fired by using the API, this way the workflow should be triggered as if the PR created event was triggering.

Signed-off-by: Sven Kanoldt <sven@d34dl0ck.me>
