### PR TITLE
chore: release v0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.2] 2025-04-05
+
+[0.23.2]: https://github.com/cargo-generate/cargo-generate/compare/0.23.1...0.23.2
+
+### 🛠️ Maintenance
+
+- Fix Cargo.toml to reflect always use version after breaking change in `cargo-util-schemas` ([#1459](https://github.com/cargo-generate/cargo-generate/issues/1459))
+
 ## [0.23.1] 2025-04-03
 
 [0.23.1]: https://github.com/cargo-generate/cargo-generate/compare/0.23.0...0.23.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "cargo-generate"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.23.1"
+version = "0.23.2"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"


### PR DESCRIPTION



## 🤖 New release

* `cargo-generate`: 0.23.1 -> 0.23.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.2] 2025-04-05

[0.23.2]: https://github.com/cargo-generate/cargo-generate/compare/0.23.1...0.23.2

### 🛠️ Maintenance

- Fix Cargo.toml to reflect always use version after breaking change in `cargo-util-schemas` ([#1459](https://github.com/cargo-generate/cargo-generate/issues/1459))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).