### PR TITLE
chore(deps): bump cargo-util-schemas to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2af4d048b76b1144c58ad66a27b05973a574cefe4999cfd2ebf5cd50213bfd"
+checksum = "e788664537bc508c6f252ca8b0e64275d89ca3ce11aeb71452a3554f390e3a65"
 dependencies = [
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ thiserror = "~2.0"
 time = "~0.3"
 toml = { version = "~0.8", features = ["preserve_order"] }
 walkdir = "~2.5"
-cargo-util-schemas = "~0.7.3"
+cargo-util-schemas = "~0.8.0"
 
 [dev-dependencies]
 assert_cmd = "~2.0"


### PR DESCRIPTION
Hello,

I'm a first time user and, when I tried installing cargo-generate, I got the same problem reported in #1468. I've updated cargo-util-schemas to 0.8.0 locally and all tests passed.