### PR TITLE
docs: fix syntax error for pre-script.rhai example

### DIFF
--- a/guide/src/templates/scripting.mini-example.md
+++ b/guide/src/templates/scripting.mini-example.md
@@ -20,7 +20,7 @@ Now, write the script in [`Rhai`], utilizing the `cargo-generate` [provided exte
 ```rhai
 // we can see existing variables.
 // note that template and Rhai variables are separate!
-let crate_type = variable::get("crate_type")
+let crate_type = variable::get("crate_type");
 debug(`crate_type: ${crate_type}`);
 
 let license = variable::get("license").to_upper();


### PR DESCRIPTION
fix syntax error for pre-script.rhai example

Error: ⛔   Failed executing script: pre-script.rhai

Caused by:
    Syntax error: Expecting ';' to terminate this statement (line 4, position 1)