### PR TITLE
fix: missing `.liquid` stripping in git templates

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -6,7 +6,7 @@ use std::{
     path::Path,
 };
 
-const LIQUID_SUFFIX: &str = ".liquid";
+pub const LIQUID_SUFFIX: &str = ".liquid";
 
 pub fn copy_files_recursively(
     src: impl AsRef<Path>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub use args::*;
 use anyhow::{anyhow, bail, Context, Result};
 use config::{locate_template_configs, Config, CONFIG_FILE_NAME};
 use console::style;
-use copy::copy_files_recursively;
+use copy::{copy_files_recursively, LIQUID_SUFFIX};
 use env_logger::fmt::Formatter;
 use fs_err as fs;
 use hooks::{execute_hooks, RhaiHooksContext};
@@ -264,6 +264,7 @@ fn get_source_template_into_temp(
             );
             if let Ok((ref temp_dir, _)) = result {
                 git::remove_history(temp_dir.path())?;
+                strip_liquid_suffixes(temp_dir.path())?;
             };
             result
         }
@@ -274,6 +275,24 @@ fn get_source_template_into_temp(
             Ok((temp_dir, try_get_branch_from_path(path)))
         }
     }
+}
+
+/// remove .liquid suffixes from git templates for parity with path templates
+fn strip_liquid_suffixes(dir: impl AsRef<Path>) -> Result<()> {
+    for entry in fs::read_dir(dir.as_ref())? {
+        let entry = entry?;
+        let entry_type = entry.file_type()?;
+
+        if entry_type.is_dir() {
+            strip_liquid_suffixes(entry.path())?;
+        } else if entry_type.is_file() {
+            let path = entry.path().to_string_lossy().to_string();
+            if let Some(new_path) = path.clone().strip_suffix(LIQUID_SUFFIX) {
+                fs::rename(path, new_path)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// resolve the template location for the actual template to expand


### PR DESCRIPTION
Caused by a regression in https://github.com/cargo-generate/cargo-generate/commit/a0dba72622b1ba903e0e7e484741d4380e303cf9.

```
(HEAD detached at a0dba72) $ ./target/debug/cargo-generate generate gibbz00/basic-things
⚠️   Favorite `gibbz00/basic-things` not found in config, using it as a git repository: https://github.com/gibbz00/basic-things.git
🤷   Project Name: test123
🔧   Destination: /tmp/test123 ...
🔧   project-name: test123 ...
🔧   Generating template ...
Error: ⛔   Failed executing script: cargo_generate/script.rhai

Caused by:
    Runtime error: No such file or directory (os error 2)
```

From the commit before:

```
(HEAD detached at ea23bab) $ ./target/debug/cargo-generate generate gibbz00/basic-things
⚠️   Favorite `gibbz00/basic-things` not found in config, using it as a git repository: https://github.com/gibbz00/basic-things.git
🤷   Project Name: test123
🔧   Destination: /tmp/test123 ...
🔧   project-name: test123 ...
🔧   Generating template ...
🤷   Repository path (usually 'username/repository_name'): 
```
