### PR TITLE
chore: release v0.23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.4] 2025-06-03
+
+[0.23.4]: https://github.com/cargo-generate/cargo-generate/compare/0.23.3...0.23.4
+
+### 📖 Documentation
+
+- Fix syntax error for pre-script.rhai example ([#1479](https://github.com/cargo-generate/cargo-generate/issues/1479))
+
+### 🛠️ Maintenance
+
+- Bump git2 from 0.20.1 to 0.20.2 ([#1485](https://github.com/cargo-generate/cargo-generate/issues/1485))
+- Bump toml from 0.8.20 to 0.8.22 ([#1483](https://github.com/cargo-generate/cargo-generate/issues/1483))
+- Bump auth-git2 from 0.5.7 to 0.5.8 ([#1493](https://github.com/cargo-generate/cargo-generate/issues/1493))
+
+### 🤕 Fixes
+
+- Missing `.liquid` stripping in git templates ([#1480](https://github.com/cargo-generate/cargo-generate/issues/1480))
+- Fix lints ([#1497](https://github.com/cargo-generate/cargo-generate/issues/1497))
+
 ## [0.23.3] 2025-04-06
 
 [0.23.3]: https://github.com/cargo-generate/cargo-generate/compare/0.23.2...0.23.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "cargo-generate"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.23.3"
+version = "0.23.4"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"


### PR DESCRIPTION



## 🤖 New release

* `cargo-generate`: 0.23.3 -> 0.23.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.4] 2025-06-03

[0.23.4]: https://github.com/cargo-generate/cargo-generate/compare/0.23.3...0.23.4

### 📖 Documentation

- Fix syntax error for pre-script.rhai example ([#1479](https://github.com/cargo-generate/cargo-generate/issues/1479))

### 🛠️ Maintenance

- Bump git2 from 0.20.1 to 0.20.2 ([#1485](https://github.com/cargo-generate/cargo-generate/issues/1485))
- Bump toml from 0.8.20 to 0.8.22 ([#1483](https://github.com/cargo-generate/cargo-generate/issues/1483))
- Bump auth-git2 from 0.5.7 to 0.5.8 ([#1493](https://github.com/cargo-generate/cargo-generate/issues/1493))

### 🤕 Fixes

- Missing `.liquid` stripping in git templates ([#1480](https://github.com/cargo-generate/cargo-generate/issues/1480))
- Fix lints ([#1497](https://github.com/cargo-generate/cargo-generate/issues/1497))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).