### PR TITLE
Fix: Excluded files in templated paths are now properly handled

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -74,7 +74,7 @@ pub fn remove_history(project_dir: &Path) -> io::Result<()> {
 
                 if e.to_string().contains("The process cannot access the file because it is being used by another process.") {
                     let wait_for = Duration::from_secs(2_u64.pow(attempt.sub(1).into()));
-                    warn!("Git history cleanup failed with a windows process blocking error. [Retry in {:?}]", wait_for);
+                    warn!("Git history cleanup failed with a windows process blocking error. [Retry in {wait_for:?}]");
                     sleep(wait_for);
                 } else {
                     return Err(e);

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -38,7 +38,7 @@ impl<F: FnOnce()> Drop for CleanupJob<F> {
 }
 
 pub fn execute_hooks(context: &RhaiHooksContext, scripts: &[String]) -> Result<()> {
-    debug!("executing rhai with context: {:?}", context);
+    debug!("executing rhai with context: {context:?}");
 
     let engine = create_rhai_engine(context);
     evaluate_scripts(&context.working_directory, scripts, engine)?;

--- a/src/include_exclude.rs
+++ b/src/include_exclude.rs
@@ -27,10 +27,9 @@ impl Matcher {
         if template_config.include.is_some() && template_config.exclude.is_some() {
             template_config.exclude = None;
             warn!(
-                "Your {} contains both an include and exclude list. \
+                "Your {CONFIG_FILE_NAME} contains both an include and exclude list. \
                     Only the include list will be considered. \
-                    You should remove the exclude list for clarity",
-                CONFIG_FILE_NAME
+                    You should remove the exclude list for clarity"
             )
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,7 +549,7 @@ fn expand_template(
         Err(e) => {
             // Don't print the error twice
             if !args.quiet && args.continue_on_error {
-                warn!("{}", e);
+                warn!("{e}");
             }
             if !args.continue_on_error {
                 return Err(e);


### PR DESCRIPTION
**Fix: Excluded files in templated paths are now properly handled**

Fix issue: #1514

**Problem**
Previously, when files were marked as excluded in the template configuration but were located within templated directory paths (e.g., `{{project-name}}/excluded-file`), the exclusion logic would simply skip processing them without considering that the directory path itself needed templating. This resulted in excluded files being ultimately ignored as they were not copied into the target directory.

**Objective**
Ensure that template exclusion rules work correctly regardless of whether the excluded files are in static or templated directory structures.

**Solution**
This fix enhances the exclusion handling logic in the `walk_dir` function to:

1. Apply filename substitution to excluded files: Even excluded files now go through the `substitute_filename` process to handle templated directory paths
2. Copy excluded files to templated locations: When an excluded file's path changes due to templating the file is copied to the new location
3. Clean up original files: After copying to the templated location, the original file in the templated path is removed
4. Preserve file content: Excluded files maintain their original content without any template processing

**Changes Made**

- Modified the `ShouldInclude::Exclude` branch in `walk_dir()` function in `template.rs`
- Added proper error handling for file operations during exclusion (I tried to follow codebase pattern and idiomatic Rust)
- Added test case `it_doesnt_process_excluded_files_in_templated_paths()` to verify the fix

**Test Coverage**
The new test verifies that:

- Excluded files in templated paths are moved to the correct final location
- Excluded files retain their original content (no template processing)
- Included files in the same templated paths are processed normally
- The exclusion configuration is respected
