### PR TITLE
fix: rhai hook return type mismatch (#1524)

### DIFF
--- a/tests/integration/helpers/arg_builder.rs
+++ b/tests/integration/helpers/arg_builder.rs
@@ -22,6 +22,11 @@ impl CargoGenerateArgBuilder {
         self.arg("--init")
     }
 
+    /// wrapper for `--allow-commands` cli flag
+    pub fn flag_allow_commands(&mut self) -> &mut Self {
+        self.arg("--allow-commands")
+    }
+
     /// wrapper for `--name <name>` cli argument
     pub fn arg_name(&mut self, name: impl AsRef<OsStr>) -> &mut Self {
         self.arg("--name").arg(name)

--- a/tests/integration/hooks_and_rhai.rs
+++ b/tests/integration/hooks_and_rhai.rs
@@ -545,3 +545,34 @@ fn missing_rhai_filter_fails_prints_warnings() {
         .read("filter-project/file_to_expand.txt")
         .contains(r#"{{"filter-script.rhai"|rhai}}"#));
 }
+
+#[test]
+fn should_echo_something() {
+    let template = tempdir()
+        .file(
+            "echo.rhai",
+            indoc! {r#"
+                system::command("echo", ["picard"]);
+            "#},
+        )
+        .file(
+            "cargo-generate.toml",
+            indoc! {r#"
+                [hooks]
+                init = ["echo.rhai"]
+            "#},
+        )
+        .init_git()
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg_git(template.path())
+        .arg_name("foo")
+        .flag_allow_commands()
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("picard").from_utf8());
+}


### PR DESCRIPTION
- when a rhai hook returns something like a string, by echoing e.g. via `system::command("echo", ["foo"]);` it is now handled and no unit type is enforced anymore
- also some debug insights are shown for further investigation needs
- fixes #1524