### PR TITLE
feat: add --no-workspace flag that skips workspace addition

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -179,6 +179,11 @@ pub struct GenerateArgs {
     #[arg(long, action, help_heading = heading::GIT_PARAMETERS)]
     pub skip_submodules: bool,
 
+    /// Skip automatic workspace member addition. When set, the generated project will not be added
+    /// to any parent Cargo.toml workspace members list
+    #[arg(long, action, help_heading = heading::OUTPUT_PARAMETERS)]
+    pub no_workspace: bool,
+
     /// All args after "--" on the command line.
     #[arg(skip)]
     pub other_args: Option<Vec<String>>,
@@ -209,6 +214,7 @@ impl Default for GenerateArgs {
             allow_commands: false,
             overwrite: false,
             skip_submodules: false,
+            no_workspace: false,
             other_args: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,18 +154,20 @@ pub fn generate(args: GenerateArgs) -> Result<PathBuf> {
     } else {
         let project_path = copy_expanded_template(template_dir, project_dir, user_parsed_input)?;
 
-        match workspace_member::add_to_workspace(&project_path)? {
-            WorkspaceMemberStatus::Added(workspace_cargo_toml) => {
-                should_initialize_git = with_force;
-                info!(
-                    "{} {} `{}`",
-                    emoji::WRENCH,
-                    style("Project added as member to workspace").bold(),
-                    style(workspace_cargo_toml.display()).bold().yellow(),
-                );
-            }
-            WorkspaceMemberStatus::NoWorkspaceFound => {
-                // not an issue, just a notification
+        if !args.no_workspace {
+            match workspace_member::add_to_workspace(&project_path)? {
+                WorkspaceMemberStatus::Added(workspace_cargo_toml) => {
+                    should_initialize_git = with_force;
+                    info!(
+                        "{} {} `{}`",
+                        emoji::WRENCH,
+                        style("Project added as member to workspace").bold(),
+                        style(workspace_cargo_toml.display()).bold().yellow(),
+                    );
+                }
+                WorkspaceMemberStatus::NoWorkspaceFound => {
+                    // not an issue, just a notification
+                }
             }
         }
 

--- a/tests/integration/helpers/arg_builder.rs
+++ b/tests/integration/helpers/arg_builder.rs
@@ -22,6 +22,11 @@ impl CargoGenerateArgBuilder {
         self.arg("--init")
     }
 
+    /// wrapper for `--no-workspace` cli flag
+    pub fn flag_no_workspace(&mut self) -> &mut Self {
+        self.arg("--no-workspace")
+    }
+
     /// wrapper for `--name <name>` cli argument
     pub fn arg_name(&mut self, name: impl AsRef<OsStr>) -> &mut Self {
         self.arg("--name").arg(name)

--- a/tests/integration/public_api.rs
+++ b/tests/integration/public_api.rs
@@ -44,6 +44,7 @@ fn it_allows_generate_call_with_public_args_and_returns_the_generated_path() {
         overwrite: false,
         other_args: None,
         skip_submodules: false,
+        no_workspace: false,
     };
 
     assert_eq!(

--- a/tests/integration/workspace_member.rs
+++ b/tests/integration/workspace_member.rs
@@ -49,3 +49,48 @@ fn it_should_add_a_new_project_to_the_workspace_members() {
             "c",
         ]"#}));
 }
+
+#[test]
+fn it_should_skip_workspace_when_no_workspace_flag_is_set() {
+    let workspace_project = tempdir()
+        .file(
+            "Cargo.toml",
+            indoc! {r#"
+                [workspace]
+                members = ["c"]
+            "#},
+        )
+        .init_git()
+        .build();
+
+    let template = tempdir()
+        .file(
+            "Cargo.toml",
+            indoc! {r#"
+                [package]
+                name = "{{project-name}}"
+                version = "0.1.0"
+            "#},
+        )
+        .init_git()
+        .build();
+
+    binary()
+        .arg_name("a")
+        .arg_path(template.path())
+        .flag_no_workspace()
+        .current_dir(workspace_project.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(workspace_project.exists("a/Cargo.toml"));
+    assert!(workspace_project
+        .read("a/Cargo.toml")
+        .contains(r#"name = "a""#));
+
+    // the workspace Cargo.toml should remain unchanged
+    let workspace_toml = workspace_project.read("Cargo.toml");
+    assert!(workspace_toml.contains(r#"members = ["c"]"#));
+    assert!(!workspace_toml.contains(r#""a""#));
+}


### PR DESCRIPTION
This change implements the suggested `--no-workspace` flag from the discussion in #1516. When specified, no attempt is made to try and find or modify a parent `Cargo.toml` workspace members list to include the newly generated project.