### PR TITLE
Fix verbatim disks in windows

### DIFF
--- a/src/absolute_path.rs
+++ b/src/absolute_path.rs
@@ -78,7 +78,7 @@ fn canonicalize_path(path: &Path) -> PathBuf {
                 result.push(component);
             }
             Component::Prefix(prefix) => match prefix.kind() {
-                std::path::Prefix::Disk(_) => {
+                std::path::Prefix::Disk(_) | std::path::Prefix::VerbatimDisk(_) => {
                     result.push(prefix.as_os_str());
                 }
                 _ => {

--- a/src/absolute_path.rs
+++ b/src/absolute_path.rs
@@ -327,7 +327,7 @@ mod tests {
     #[test]
     fn test_verbatim_disk_path_canonicalization() {
         // Verbatim disks should not be stripped during canonicalization
-        let root_path = PathBuf::from(r"\\?\D:\");
+        let root_path = PathBuf::from(r"\\?\D:\path");
 
         assert_eq!(root_path, canonicalize_path(&root_path));
     }

--- a/src/absolute_path.rs
+++ b/src/absolute_path.rs
@@ -323,4 +323,12 @@ mod tests {
         let some_malicious_path = PathBuf::from("///file.txt");
         some_malicious_path.as_sandboxed_absolute(&sandbox).unwrap();
     }
+
+    #[test]
+    fn test_verbatim_disk_path_canonicalization() {
+        // Verbatim disks should not be stripped during canonicalization
+        let root_path = PathBuf::from(r"\\?\D:\");
+
+        assert_eq!(root_path, canonicalize_path(&root_path));
+    }
 }

--- a/src/template_filters.rs
+++ b/src/template_filters.rs
@@ -104,7 +104,7 @@ impl ParseFilter for RhaiFilterParser {
     fn parse(&self, mut args: FilterArguments) -> liquid_core::Result<Box<dyn Filter>> {
         if args.positional.next().is_some() {
             return Err(Error::with_msg("Invalid number of positional arguments")
-                .context("cause", concat!("expected at most 0 positional arguments")));
+                .context("cause", "expected at most 0 positional arguments"));
         }
         if let Some(arg) = args.keyword.next() {
             return Err(Error::with_msg(format!(


### PR DESCRIPTION
In some windows setups, the path tempdir generates is prefixed by `\\?\` making it a verbatim path. The current `canonicalize_path` function strips the prefix turning `\\?\C:\temp\...` into `\temp\...` which results in either a silent failure in the case of `file::delete` or a network error in the case of `file::listdir`

This PR fixes that issue by allowing verbatim disk paths

Fixes https://github.com/DioxusLabs/dioxus-template/issues/78
Fixes #1540