### PR TITLE
feat: be less restrictive with `tempfile` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,15 +2035,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rhai = "~1.23"
 sanitize-filename = "~0.6"
 semver = { version = "~1.0", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive"] }
-tempfile = "~3.20"
+tempfile = "3.23.0"
 thiserror = "~2.0"
 time = "~0.3"
 toml = { version = "~0.9", features = ["preserve_order"] }


### PR DESCRIPTION
This causes issues when depending on the head of the [`wasmtime`](https://github.com/bytecodealliance/wasmtime/tree/main) repo, as it uses tempfile [`3.23.0`](https://github.com/bytecodealliance/wasmtime/blob/main/Cargo.toml#L390) (the latest version), but `cargo-generate` conflicts with its choice of `~3.20.0`, which only allows resolving with a different patch version (instead of minor), resulting in the following error:

```sh
/dev/mono/src/rust/test-tempfile> cargo check
    Blocking waiting for file lock on package cache
    Updating git repository `https://github.com/bytecodealliance/wasmtime`
    Updating git submodule `https://github.com/WebAssembly/component-model`
    Updating git submodule `https://github.com/WebAssembly/testsuite`
    Updating git submodule `https://github.com/WebAssembly/wasi-testsuite.git`
    Updating git submodule `https://github.com/WebAssembly/wasi-threads`
    Updating crates.io index
error: failed to select a version for `tempfile`.
    ... required by package `wasmtime v40.0.0 (https://github.com/bytecodealliance/wasmtime#0b9ff9bf)`
    ... which satisfies git dependency `wasmtime` of package `test-tempfile v0.1.0 (/Users/theo/dev/mono/src/rust/test-tempfile)`
versions that meet the requirements `^3.23.0` are: 3.23.0

all possible versions conflict with previously selected packages.

  previously selected package `tempfile v3.20.0`
    ... which satisfies dependency `tempfile = "~3.20"` (locked to 3.20.0) of package `cargo-generate v0.23.6`
    ... which satisfies dependency `cargo-generate = "^0.23.6"` (locked to 0.23.6) of package `test-tempfile v0.1.0 (/Users/theo/dev/mono/src/rust/test-tempfile)`

failed to select a version for `tempfile` which could resolve this conflict
```

You can reproduce this with a `Cargo.toml` like so:
```toml
[package]
name = "test-tempfile"
version = "0.1.0"
edition = "2024"

[dependencies]
cargo-generate = "0.23.6"
wasmtime = { git = "https://github.com/bytecodealliance/wasmtime" }
```

The cargo book [generally recommends caret requirements](https://doc.rust-lang.org/nightly/cargo/reference/resolver.html#recommendations) for most situations, so this change seems like a fine choice to me 🤷 