### PR TITLE
chore: release v0.23.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/cargo-generate/cargo-generate/compare/v0.23.3...HEAD)
 
+## [0.23.8] 2026-04-01
+
+[0.23.8]: https://github.com/cargo-generate/cargo-generate/compare/0.23.5...0.23.8
+
+### 🛠️ Maintenance
+
+- Bump cargo-util-schemas from 0.10.0 to 0.10.1 ([#1594](https://github.com/cargo-generate/cargo-generate/issues/1594))
+- Batch dependency updates ([#1623](https://github.com/cargo-generate/cargo-generate/issues/1623))
+- Replace unmaintained `paste` crate with `pastey` ([#1624](https://github.com/cargo-generate/cargo-generate/issues/1624))
+- Verify local paths take precedence over org/repo in --git ([#1638](https://github.com/cargo-generate/cargo-generate/issues/1638))
+
+### 🤕 Fixes
+
+- Expand abbreviated URLs for --git flag ([#1625](https://github.com/cargo-generate/cargo-generate/issues/1625))
+
+
 ## [0.23.7] 2025-11-20
 
 [0.23.7]: https://github.com/cargo-generate/cargo-generate/compare/0.23.6...0.23.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cargo-generate"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-generate"
 description = "cargo, make me a project"
-version = "0.23.7"
+version = "0.23.8"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cargo-generate/cargo-generate"


### PR DESCRIPTION



## 🤖 New release

* `cargo-generate`: 0.23.7 -> 0.23.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.5] 2025-08-22

[0.23.5]: https://github.com/cargo-generate/cargo-generate/compare/0.23.4...0.23.5

### 🛠️ Maintenance

- Bump toml from 0.8.23 to 0.9.2 ([#1521](https://github.com/cargo-generate/cargo-generate/issues/1521))
- Fix verbatim disks in windows ([#1539](https://github.com/cargo-generate/cargo-generate/issues/1539))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).