### PR TITLE
Fix typos in guide

### DIFF
--- a/guide/src/templates/README.md
+++ b/guide/src/templates/README.md
@@ -18,7 +18,7 @@ Only files that are **not** listed in the exclude settings will be templated.
 
 > ⚠️ NOTE: invalid characters for a filename or directory name will be sanitized after template substitution. Invalid is e.g. `/` or `\`.
 
-> ⚠️ **Deprecated** in favor of using [ignore in `cargo-generate.toml`](#Ignoring-files)
+> ⚠️ **Deprecated** in favor of using [ignore in `cargo-generate.toml`](https://cargo-generate.github.io/cargo-generate/templates/ignoring.html)
 >
 > You can also add a `.genignore` file to your template. The files listed in the `.genignore` file
 > will be removed from the local machine when `cargo-generate` is run on the end user's machine.

--- a/guide/src/templates/authoring.md
+++ b/guide/src/templates/authoring.md
@@ -7,7 +7,7 @@ As a template author you're probably concerned about successful builds of your t
 Imagine a couple of months after your first template release, some new versions of any dependencies
 would break your template, and you would not even be aware of it?
 
-The answer to this question is a vital build pipeline for your template project. This challenge got now
+The answer to this question is a vital build pipeline for your template project. This challenge got
 much simpler to solve with the new official [cargo-generate GitHub Action](https://github.com/marketplace/actions/cargo-generate).
 
 Here is an example:

--- a/guide/src/templates/template_defined_placeholders.md
+++ b/guide/src/templates/template_defined_placeholders.md
@@ -122,4 +122,4 @@ placeholder2 = "default value for favorite"
 
 ## Further examples
 
-You can find further examples in the [example-templates folder](/example-templates/) that provide some template provided placeholders.
+You can find further examples in the [example-templates folder](https://github.com/cargo-generate/cargo-generate/tree/main/example-templates) that provide some template provided placeholders.


### PR DESCRIPTION
# Update deprecation note with correct link

Seems this may have been on the same page before but was later moved. Didn't check the history but I think this is where the link was meant to point to.