### PR TITLE
fix: satisfy Rust 1.95.0 clippy useless_conversion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ fn test_expanded_template(template_dir: &PathBuf, args: Option<Vec<String>>) -> 
     );
     std::process::Command::new(cmd)
         .args(cmd_args)
-        .args(args.unwrap_or_default().into_iter())
+        .args(args.unwrap_or_default())
         .spawn()?
         .wait()?
         .success()


### PR DESCRIPTION
## Summary
- Rust 1.95.0 extended the `clippy::useless_conversion` lint to catch explicit `.into_iter()` on arguments that already accept `IntoIterator`, breaking all lint jobs on main and every open PR (e.g. #1653).
- Applies the exact fix suggested by clippy in `src/lib.rs:236`.

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes locally on Rust 1.95.0