### PR TITLE
fix: retire process-wide CWD mutation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "fs-err",
  "git2",
  "gix-config",
+ "gix-hash",
  "heck",
  "home",
  "ignore",
@@ -702,23 +703,20 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.36.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636ca0d7bf8f7ad8ba84a5dda8312c8944b275be09d88b072e08f57d3e47c1e8"
+checksum = "272916673b83714734b15d4ef3c8b5f1ccddb15fea8ff548430b97c1ab7b7ed8"
 dependencies = [
  "bstr",
  "gix-date",
- "gix-utils",
- "itoa",
- "thiserror",
- "winnow 0.7.15",
+ "gix-error",
 ]
 
 [[package]]
 name = "gix-config"
-version = "0.48.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9419284839421488b5ab9b9b88386bdc1e159a986c08e17ffa3e9a5cd2b139f5"
+checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -727,18 +725,16 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "memchr",
  "smallvec",
  "thiserror",
  "unicode-bom",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.15.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c489abb061c74b0c3ad790e24a606ef968cebab48ec673d6a891ece7d5aef64"
+checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
 dependencies = [
  "bitflags",
  "bstr",
@@ -749,22 +745,31 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.11.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a1259955c76335c9d1a8c511811b10dbc800ffeeca3daea1e0aadd0c98f6b7"
+checksum = "b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543"
 dependencies = [
  "bstr",
+ "gix-error",
  "itoa",
  "jiff",
  "smallvec",
- "thiserror",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613"
+dependencies = [
+ "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.44.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa64593d1586135102307fb57fb3a9d3868b6b1f45a4da1352cce5070f8916a"
+checksum = "af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f"
 dependencies = [
  "gix-path",
  "gix-trace",
@@ -776,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.17.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1ecd896258cdc5ccd94d18386d17906b8de265ad2ecf68e3bea6b007f6a28f"
+checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
 dependencies = [
  "bstr",
  "fastrand",
@@ -790,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.22.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74254992150b0a88fdb3ad47635ab649512dff2cbbefca7916bb459894fc9d56"
+checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
 dependencies = [
  "bitflags",
  "bstr",
@@ -802,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.20.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826036a9bee95945b0be1e2394c64cd4289916c34a639818f8fd5153906985c1"
+checksum = "bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -814,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.10.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27d4a3ea9640da504a2657fef3419c517fd71f1767ad8935298bcc805edd195"
+checksum = "d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -825,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "19.0.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729d7857429a66023bc0c29d60fa21d0d6ae8862f33c1937ba89e0f74dd5c67f"
+checksum = "09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -836,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.52.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84743d1091c501a56f00d7f4c595cb30f20fcef6503b32ac0a1ff3817efd7b5d"
+checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -846,20 +851,18 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "gix-hashtable",
- "gix-path",
  "gix-utils",
  "gix-validate",
  "itoa",
  "smallvec",
  "thiserror",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-path"
-version = "0.10.22"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -869,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.55.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51330a32f173c8e831731dfef8e93a748c23c057f4b028841f222564cad84cb"
+checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -885,14 +888,13 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-sec"
-version = "0.12.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
+checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
 dependencies = [
  "bitflags",
  "gix-path",
@@ -902,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "19.0.1"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e265fc6b54e57693232a79d84038381ebfda7b1a3b1b8a9320d4d5fe6e820086"
+checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
 dependencies = [
  "gix-fs",
  "libc",
@@ -930,12 +932,11 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
 dependencies = [
  "bstr",
- "thiserror",
 ]
 
 [[package]]
@@ -1730,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "prodash"
-version = "30.0.1"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
 dependencies = [
  "parking_lot",
 ]
@@ -2266,7 +2267,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -2293,7 +2294,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -2660,15 +2661,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "walkdir",
 ]
@@ -233,7 +233,7 @@ dependencies = [
  "serde-untagged",
  "serde-value",
  "thiserror",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "unicode-ident",
  "url",
 ]
@@ -383,9 +383,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
 ]
@@ -641,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1163,15 +1163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1862,19 +1853,19 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.23.6"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e35aaaa439a5bda2f8d15251bc375e4edfac75f9865734644782c9701b5709"
+checksum = "1f9ef5dabe4c0b43d8f1187dc6beb67b53fe607fff7e30c5eb7f71b814b8c2c1"
 dependencies = [
  "ahash",
  "bitflags",
- "instant",
  "num-traits",
  "once_cell",
  "rhai_codegen",
  "smallvec",
  "smartstring",
  "thin-vec",
+ "web-time",
 ]
 
 [[package]]
@@ -2258,13 +2249,24 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2272,6 +2274,15 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,10 @@ console = "~0.16"
 dialoguer = "~0.12"
 env_logger = "~0.11"
 fs-err = "~3.3"
-gix-config = "~0.48"
+gix-config = "~0.56"
+# gix-config 0.56's transitive deps need gix-hash with a hash-kind feature enabled;
+# otherwise gix-hash's Kind enum is empty and the crate fails to compile.
+gix-hash = { version = "~0.25", default-features = false, features = ["sha1"] }
 heck = "~0.5"
 home = "~0.5"
 ignore = "~0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "~4.6", features = ["derive", "wrap_help"] }
 console = "~0.16"
 dialoguer = "~0.12"
 env_logger = "~0.11"
-fs-err = "~3.2"
+fs-err = "~3.3"
 gix-config = "~0.48"
 heck = "~0.5"
 home = "~0.5"
@@ -38,14 +38,14 @@ openssl = { version = "~0.10", optional = true }
 pastey = "~0.2"
 regex = "~1.12"
 remove_dir_all = "~1.0"
-rhai = "~1.23"
+rhai = "~1.24"
 sanitize-filename = "~0.6"
 semver = { version = "~1.0", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive"] }
 tempfile = "3.27.0"
 thiserror = "~2.0"
 time = "~0.3"
-toml = { version = "~0.9", features = ["preserve_order"] }
+toml = { version = "~1.1", features = ["preserve_order"] }
 walkdir = "~2.5"
 cargo-util-schemas = "~0.13"
 

--- a/src/git/clone_tool.rs
+++ b/src/git/clone_tool.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
@@ -6,6 +7,10 @@ use auth_git2::GitAuthenticator;
 use console::style;
 use git2::{build::RepoBuilder, Config, FetchOptions, ProxyOptions, Repository};
 use log::debug;
+
+fn interactive_auth_allowed() -> bool {
+    std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
+}
 
 use crate::emoji::WRENCH;
 
@@ -28,11 +33,14 @@ impl<'cb> RepoCloneBuilder<'cb> {
         #[cfg(windows)]
         let authenticator = GitAuthenticator::default().try_ssh_agent(true);
         #[cfg(not(windows))]
-        let authenticator = GitAuthenticator::default()
-            .try_ssh_agent(true)
-            .add_default_ssh_keys()
-            .prompt_ssh_key_password(true)
-            .try_password_prompt(3);
+        let authenticator = {
+            let interactive = interactive_auth_allowed();
+            GitAuthenticator::default()
+                .try_ssh_agent(true)
+                .add_default_ssh_keys()
+                .prompt_ssh_key_password(interactive)
+                .try_password_prompt(if interactive { 3 } else { 0 })
+        };
 
         Self {
             builder: RepoBuilder::new(),
@@ -85,11 +93,12 @@ impl<'cb> RepoCloneBuilder<'cb> {
                 style("for git-ssh checkout").bold()
             );
 
+            let interactive = interactive_auth_allowed();
             self.authenticator = self
                 .authenticator
                 .add_ssh_key_from_file(identity_path, None)
-                .try_password_prompt(3)
-                .prompt_ssh_key_password(true)
+                .try_password_prompt(if interactive { 3 } else { 0 })
+                .prompt_ssh_key_password(interactive);
         }
 
         Ok(self)

--- a/src/git/clone_tool.rs
+++ b/src/git/clone_tool.rs
@@ -26,21 +26,20 @@ pub struct RepoCloneBuilder<'cb> {
     destination_path: Option<PathBuf>,
     tag_or_revision: Option<String>,
     gitconfig: Option<Config>,
+    interactive: bool,
 }
 
 impl<'cb> RepoCloneBuilder<'cb> {
     pub fn new(url: &str) -> Self {
+        let interactive = interactive_auth_allowed();
         #[cfg(windows)]
         let authenticator = GitAuthenticator::default().try_ssh_agent(true);
         #[cfg(not(windows))]
-        let authenticator = {
-            let interactive = interactive_auth_allowed();
-            GitAuthenticator::default()
-                .try_ssh_agent(true)
-                .add_default_ssh_keys()
-                .prompt_ssh_key_password(interactive)
-                .try_password_prompt(if interactive { 3 } else { 0 })
-        };
+        let authenticator = GitAuthenticator::default()
+            .try_ssh_agent(true)
+            .add_default_ssh_keys()
+            .prompt_ssh_key_password(interactive)
+            .try_password_prompt(if interactive { 3 } else { 0 });
 
         Self {
             builder: RepoBuilder::new(),
@@ -50,6 +49,7 @@ impl<'cb> RepoCloneBuilder<'cb> {
             destination_path: None,
             tag_or_revision: None,
             gitconfig: None,
+            interactive,
         }
     }
 
@@ -93,7 +93,7 @@ impl<'cb> RepoCloneBuilder<'cb> {
                 style("for git-ssh checkout").bold()
             );
 
-            let interactive = interactive_auth_allowed();
+            let interactive = self.interactive;
             self.authenticator = self
                 .authenticator
                 .add_ssh_key_from_file(identity_path, None)

--- a/src/hooks/file_mod.rs
+++ b/src/hooks/file_mod.rs
@@ -140,7 +140,6 @@ mod tests {
         let tmp_dir = prepare_file_system();
         let context = prepare_context(&tmp_dir);
         let engine = create_rhai_engine(&context);
-        std::env::set_current_dir(tmp_dir.path()).unwrap();
 
         let files = engine.eval::<Array>("file::listdir()").unwrap();
         assert_eq!(files.len(), 2);
@@ -158,7 +157,6 @@ mod tests {
         let tmp_dir = prepare_file_system();
         let context = prepare_context(&tmp_dir);
         let engine = create_rhai_engine(&context);
-        std::env::set_current_dir(tmp_dir.path()).unwrap();
 
         // cover the other listdir function with one path argument
         let files = engine.eval::<Array>(r#"file::listdir(".")"#).unwrap();
@@ -179,7 +177,6 @@ mod tests {
         let tmp_dir = prepare_file_system();
         let context = prepare_context(&tmp_dir);
         let engine = create_rhai_engine(&context);
-        std::env::set_current_dir(tmp_dir.path()).unwrap();
 
         let path_argument = "../../../../etc";
         engine
@@ -194,7 +191,6 @@ mod tests {
         let tmp_dir = prepare_file_system();
         let context = prepare_context(&tmp_dir);
         let engine = create_rhai_engine(&context);
-        std::env::set_current_dir(tmp_dir.path()).unwrap();
 
         let path_argument = "////../../../../etc";
         engine

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -7,9 +7,10 @@ use heck::{
 };
 use liquid::ValueView;
 use log::debug;
+use rhai::module_resolvers::FileModuleResolver;
 use rhai::EvalAltResult;
+use std::path::Path;
 use std::path::PathBuf;
-use std::{env, path::Path};
 
 use crate::emoji;
 use crate::template::LiquidObjectResource;
@@ -22,21 +23,7 @@ mod variable_mod;
 
 type HookResult<T> = std::result::Result<T, Box<EvalAltResult>>;
 
-struct CleanupJob<F: FnOnce()>(Option<F>);
-
 pub use context::RhaiHooksContext;
-
-impl<F: FnOnce()> CleanupJob<F> {
-    pub const fn new(f: F) -> Self {
-        Self(Some(f))
-    }
-}
-
-impl<F: FnOnce()> Drop for CleanupJob<F> {
-    fn drop(&mut self) {
-        self.0.take().unwrap()();
-    }
-}
 
 pub fn execute_hooks(context: &RhaiHooksContext, scripts: &[String]) -> Result<()> {
     debug!("executing rhai with context: {context:?}");
@@ -47,14 +34,8 @@ pub fn execute_hooks(context: &RhaiHooksContext, scripts: &[String]) -> Result<(
 }
 
 fn evaluate_scripts(template_dir: &Path, scripts: &[String], engine: rhai::Engine) -> Result<()> {
-    let cwd = env::current_dir()?;
-    let _ = CleanupJob::new(move || {
-        env::set_current_dir(cwd).ok();
-    });
-    env::set_current_dir(template_dir)?;
-
     for script in scripts {
-        let script: PathBuf = script.into();
+        let script: PathBuf = template_dir.join(script);
 
         let result = engine
             .eval_file::<rhai::plugin::Dynamic>(script.clone())
@@ -142,44 +123,43 @@ pub fn evaluate_script<T: Clone + 'static>(
 pub fn create_rhai_engine(context: &RhaiHooksContext) -> rhai::Engine {
     let mut engine = rhai::Engine::new();
 
-    // register modules
-    let module = variable_mod::create_module(&context.liquid_object);
-    engine.register_static_module("variable", module.into());
-
-    let module = file_mod::create_module(&context.working_directory);
-    engine.register_static_module("file", module.into());
-
-    let module = system_mod::create_module(
+    let var_mod = variable_mod::create_module(&context.liquid_object);
+    let file_mod = file_mod::create_module(&context.working_directory);
+    let system_mod = system_mod::create_module(
         context.working_directory.clone(),
         context.allow_commands,
         context.silent,
     );
-    engine.register_static_module("system", module.into());
-
-    let module = env_mod::create_module(Environment {
+    let env_mod = env_mod::create_module(Environment {
         working_directory: context.working_directory.clone(),
         destination_directory: context.destination_directory.clone(),
     });
-    engine.register_static_module("env", module.into());
 
-    // register functions for changing case
-    engine.register_fn("to_kebab_case", |str: &str| str.to_kebab_case());
-    engine.register_fn("to_lower_camel_case", |str: &str| str.to_lower_camel_case());
-    engine.register_fn("to_pascal_case", |str: &str| str.to_pascal_case());
-    engine.register_fn("to_shouty_kebab_case", |str: &str| {
-        str.to_shouty_kebab_case()
-    });
-    engine.register_fn("to_shouty_snake_case", |str: &str| {
-        str.to_shouty_snake_case()
-    });
-    engine.register_fn("to_snake_case", |str: &str| str.to_snake_case());
-    engine.register_fn("to_title_case", |str: &str| str.to_title_case());
-    engine.register_fn("to_upper_camel_case", |str: &str| str.to_upper_camel_case());
-
-    // other free-standing functions
-    engine.register_fn("abort", |error: &str| -> HookResult<String> {
-        Err(error.into())
-    });
+    engine
+        .set_module_resolver(FileModuleResolver::new_with_path(
+            &context.working_directory,
+        ))
+        .register_static_module("variable", var_mod.into())
+        .register_static_module("file", file_mod.into())
+        .register_static_module("system", system_mod.into())
+        .register_static_module("env", env_mod.into())
+        // register functions for changing case
+        .register_fn("to_kebab_case", |str: &str| str.to_kebab_case())
+        .register_fn("to_lower_camel_case", |str: &str| str.to_lower_camel_case())
+        .register_fn("to_pascal_case", |str: &str| str.to_pascal_case())
+        .register_fn("to_shouty_kebab_case", |str: &str| {
+            str.to_shouty_kebab_case()
+        })
+        .register_fn("to_shouty_snake_case", |str: &str| {
+            str.to_shouty_snake_case()
+        })
+        .register_fn("to_snake_case", |str: &str| str.to_snake_case())
+        .register_fn("to_title_case", |str: &str| str.to_title_case())
+        .register_fn("to_upper_camel_case", |str: &str| str.to_upper_camel_case())
+        // other free-standing functions
+        .register_fn("abort", |error: &str| -> HookResult<String> {
+            Err(error.into())
+        });
 
     engine
 }

--- a/src/hooks/system_mod.rs
+++ b/src/hooks/system_mod.rs
@@ -174,7 +174,6 @@ mod tests {
             allow_commands: true,
             silent: true,
         };
-        std::env::set_current_dir(&context.working_directory).unwrap();
         let engine = create_rhai_engine(&context);
 
         let pwd = engine.eval::<String>(r#"system::command("pwd")"#).unwrap();
@@ -225,7 +224,6 @@ mod tests {
             silent: true,
         };
         let engine = create_rhai_engine(&context);
-        std::env::set_current_dir(tmp_dir.path()).unwrap();
 
         engine
             .eval::<String>(r#"system::command("nonexistent_command")"#)
@@ -246,7 +244,6 @@ mod tests {
             silent: true,
         };
         let engine = create_rhai_engine(&context);
-        std::env::set_current_dir(tmp_dir.path()).unwrap();
 
         engine
             .eval::<String>(r#"system::command("echo", ["hello"])"#)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,6 @@ pub fn log_formatter(
 
 /// # Panics
 pub fn generate(args: GenerateArgs) -> Result<PathBuf> {
-    let _working_dir_scope = ScopedWorkingDirectory::default();
-
     let app_config = AppConfig::try_from(app_config_path(&args.config)?.as_path())?;
 
     // mash AppConfig and CLI arguments together into UserParsedInput
@@ -150,7 +148,7 @@ pub fn generate(args: GenerateArgs) -> Result<PathBuf> {
     };
 
     let target_path = if user_parsed_input.test() {
-        test_expanded_template(&template_dir, args.other_args)?
+        test_expanded_template(args.other_args)?
     } else {
         let project_path = copy_expanded_template(template_dir, project_dir, user_parsed_input)?;
 
@@ -212,7 +210,7 @@ fn copy_expanded_template(
     Ok(project_dir)
 }
 
-fn test_expanded_template(template_dir: &PathBuf, args: Option<Vec<String>>) -> Result<PathBuf> {
+fn test_expanded_template(args: Option<Vec<String>>) -> Result<PathBuf> {
     info!(
         "{} {}{}{}",
         emoji::WRENCH,
@@ -220,7 +218,6 @@ fn test_expanded_template(template_dir: &PathBuf, args: Option<Vec<String>>) -> 
         style("cargo test"),
         style("\" ...").bold(),
     );
-    std::env::set_current_dir(template_dir)?;
     let (cmd, cmd_args) = std::env::var("CARGO_GENERATE_TEST_CMD").map_or_else(
         |_| (String::from("cargo"), vec![String::from("test")]),
         |env_test_cmd| {
@@ -774,21 +771,6 @@ fn check_cargo_generate_version(template_config: &Config) -> Result<(), anyhow::
         }
     }
     Ok(())
-}
-
-#[derive(Debug)]
-struct ScopedWorkingDirectory(PathBuf);
-
-impl Default for ScopedWorkingDirectory {
-    fn default() -> Self {
-        Self(env::current_dir().unwrap())
-    }
-}
-
-impl Drop for ScopedWorkingDirectory {
-    fn drop(&mut self) {
-        env::set_current_dir(&self.0).unwrap();
-    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod progressbar;
 mod project_variables;
 mod template;
 mod template_filters;
+mod template_source;
 mod template_variables;
 mod user_parsed_input;
 mod workspace_member;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ pub fn generate(args: GenerateArgs) -> Result<PathBuf> {
     };
 
     let target_path = if user_parsed_input.test() {
-        test_expanded_template(args.other_args)?
+        test_expanded_template(&template_dir, args.other_args)?
     } else {
         let project_path = copy_expanded_template(template_dir, project_dir, user_parsed_input)?;
 
@@ -210,7 +210,7 @@ fn copy_expanded_template(
     Ok(project_dir)
 }
 
-fn test_expanded_template(args: Option<Vec<String>>) -> Result<PathBuf> {
+fn test_expanded_template(template_dir: &Path, args: Option<Vec<String>>) -> Result<PathBuf> {
     info!(
         "{} {}{}{}",
         emoji::WRENCH,
@@ -229,6 +229,7 @@ fn test_expanded_template(args: Option<Vec<String>>) -> Result<PathBuf> {
         },
     );
     std::process::Command::new(cmd)
+        .current_dir(template_dir)
         .args(cmd_args)
         .args(args.unwrap_or_default())
         .spawn()?

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use anyhow::Result;
 use cargo_generate::{generate, list_favorites, Cli};
 use clap::Parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,13 +46,13 @@ fn resolve_args() -> cargo_generate::GenerateArgs {
 
     args.other_args = Some(other_args);
     if args.template_path.test {
-        args.template_path.path = Some(
-            args.template_path
-                .auto_path
-                .take()
-                .map(|sub| PathBuf::from(".").join(sub).display().to_string())
-                .unwrap_or_else(|| String::from(".")),
-        );
+        if args.template_path.auto_path.is_none() {
+            args.template_path.path = Some(String::from("."));
+        }
+        // If auto_path is set, leave it alone — try_from_args_and_config's
+        // resolver (classify) decides whether it's a local dir or a remote
+        // spec. This stops --test from hijacking github shorthands away from
+        // the resolver.
         if args.name.is_none() {
             args.name = names::Generator::default().next();
         }

--- a/src/template_filters.rs
+++ b/src/template_filters.rs
@@ -155,34 +155,24 @@ impl Filter for RhaiFilter {
         let engine = create_rhai_engine(&context);
         let script_name = input.to_kstr().to_string();
         let file_path = self.template_dir.join(&script_name);
-        if !file_path.exists() {
-            warn!(
-                "{} {} {}",
-                style("Filter script").bold().yellow(),
-                style(&script_name).bold().red(),
-                style("not found").bold().yellow(),
-            );
-            return Err(liquid_core::Error::with_msg(format!(
-                "Filter script {script_name} not found"
-            )));
-        }
         self.rhai_filter_files
             .lock()
             .map_err(|_| liquid_core::Error::with_msg(PoisonError.to_string()))?
             .push(file_path.clone());
 
-        let result = engine.eval_file::<String>(file_path.clone());
-        match result {
+        match engine.eval_file::<String>(file_path) {
             Ok(r) => Ok(Value::Scalar(model::Scalar::from(r))),
             Err(err) => {
                 warn!(
                     "{} {} {} {}",
                     style("Filter script").bold().yellow(),
-                    style(file_path.display()).bold().red(),
-                    style("contained error").bold().yellow(),
+                    style(&script_name).bold().red(),
+                    style("not found or failed:").bold().yellow(),
                     style(err.to_string()).bold().red(),
                 );
-                Err(liquid_core::Error::with_msg(err.to_string()))
+                Err(liquid_core::Error::with_msg(format!(
+                    "Filter script {script_name} not found or failed: {err}"
+                )))
             }
         }
     }

--- a/src/template_filters.rs
+++ b/src/template_filters.rs
@@ -153,17 +153,17 @@ impl Filter for RhaiFilter {
         };
 
         let engine = create_rhai_engine(&context);
-        let file_path = PathBuf::from(input.to_kstr().to_string());
+        let script_name = input.to_kstr().to_string();
+        let file_path = self.template_dir.join(&script_name);
         if !file_path.exists() {
             warn!(
                 "{} {} {}",
                 style("Filter script").bold().yellow(),
-                style(file_path.display()).bold().red(),
+                style(&script_name).bold().red(),
                 style("not found").bold().yellow(),
             );
             return Err(liquid_core::Error::with_msg(format!(
-                "Filter script {} not found",
-                file_path.display()
+                "Filter script {script_name} not found"
             )));
         }
         self.rhai_filter_files

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -119,18 +119,20 @@ impl TemplateSource {
         // 1. Configured favorite name (only when within recursion budget).
         if depth <= FAVORITE_RECURSION_LIMIT {
             if let Some(fav) = app_config.get_favorite_cfg(input) {
-                let inner = if let Some(git) = fav.git.as_deref() {
-                    Self::classify_with_depth(git, app_config, cwd, depth + 1)
-                } else if let Some(p) = fav.path.as_ref() {
-                    if p.is_absolute() {
+                if let Some(git) = fav.git.as_deref() {
+                    let inner = Self::classify_with_depth(git, app_config, cwd, depth + 1);
+                    return Self::Favorite(Box::new(inner));
+                }
+                if let Some(p) = fav.path.as_ref() {
+                    let inner = if p.is_absolute() {
                         Self::LocalAbsolute(p.clone())
                     } else {
                         Self::LocalRelative(cwd.join(p))
-                    }
-                } else {
-                    Self::RemoteUrl(input.to_owned())
-                };
-                return Self::Favorite(Box::new(inner));
+                    };
+                    return Self::Favorite(Box::new(inner));
+                }
+                // Malformed favorite (neither git nor path) — fall through to
+                // non-favorite classification rules below.
             }
         }
 
@@ -395,5 +397,23 @@ mod tests {
     #[test]
     fn parse_owner_repo_rejects_no_slash() {
         assert_eq!(parse_owner_repo("ownerrepo"), None);
+    }
+
+    #[test]
+    fn classify_malformed_favorite_falls_through_to_non_favorite() {
+        use crate::app_config::FavoriteConfig;
+        use std::collections::HashMap;
+        let mut favorites = HashMap::new();
+        // Malformed favorite: name is set but neither git nor path is.
+        favorites.insert("just-a-name".to_owned(), FavoriteConfig::default());
+        let cfg = AppConfig {
+            favorites: Some(favorites),
+            ..AppConfig::default()
+        };
+        let cwd = tempfile::TempDir::new().unwrap();
+        let s = TemplateSource::classify("just-a-name", &cfg, cwd.path());
+        // No `/`, no scheme, no local dir → catch-all RemoteUrl with the
+        // verbatim input, NOT wrapped in Favorite.
+        assert_eq!(s, TemplateSource::RemoteUrl("just-a-name".to_owned()));
     }
 }

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -164,6 +164,39 @@ impl TemplateSource {
         // 7. Catch-all — let git produce the clearer error.
         Self::RemoteUrl(input.to_owned())
     }
+
+    /// User-facing label preserving the form the user typed. Used in
+    /// warnings, log lines, error messages.
+    pub fn display_label(&self) -> std::borrow::Cow<'_, str> {
+        use std::borrow::Cow;
+        match self {
+            Self::HostShorthand { host, owner_repo } => {
+                let prefix = match host {
+                    GitHost::GitHub => "gh",
+                    GitHost::GitLab => "gl",
+                    GitHost::Bitbucket => "bb",
+                    GitHost::SourceHut => "sr",
+                };
+                Cow::Owned(format!("{prefix}:{owner_repo}"))
+            }
+            Self::GithubOwnerRepo { owner, repo } => Cow::Owned(format!("{owner}/{repo}")),
+            Self::RemoteUrl(url) => Cow::Borrowed(url.as_str()),
+            Self::LocalRelative(p) | Self::LocalAbsolute(p) => {
+                Cow::Owned(p.display().to_string())
+            }
+            Self::Favorite(inner) => Cow::Owned(format!("favorite → {}", inner.display_label())),
+        }
+    }
+
+    /// Whether this source should be acquired by cloning vs copying.
+    /// Favorites delegate to their inner source.
+    pub fn is_remote(&self) -> bool {
+        match self {
+            Self::HostShorthand { .. } | Self::GithubOwnerRepo { .. } | Self::RemoteUrl(_) => true,
+            Self::LocalRelative(_) | Self::LocalAbsolute(_) => false,
+            Self::Favorite(inner) => inner.is_remote(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -495,5 +528,67 @@ mod tests {
         // The exact deep structure doesn't matter; what matters is that
         // classify terminates and produces something well-formed.
         assert!(matches!(s, TemplateSource::Favorite(_)));
+    }
+
+    #[test]
+    fn display_label_host_shorthand() {
+        let s = TemplateSource::HostShorthand {
+            host: GitHost::GitHub,
+            owner_repo: "o/r".to_owned(),
+        };
+        assert_eq!(s.display_label(), "gh:o/r");
+    }
+    #[test]
+    fn display_label_owner_repo() {
+        let s = TemplateSource::GithubOwnerRepo {
+            owner: "o".to_owned(),
+            repo: "r".to_owned(),
+        };
+        assert_eq!(s.display_label(), "o/r");
+    }
+    #[test]
+    fn display_label_remote_url() {
+        let s = TemplateSource::RemoteUrl("https://x/y".to_owned());
+        assert_eq!(s.display_label(), "https://x/y");
+    }
+    #[test]
+    fn display_label_local_relative() {
+        let s = TemplateSource::LocalRelative(PathBuf::from("./t"));
+        assert_eq!(s.display_label(), "./t");
+    }
+    #[test]
+    fn display_label_local_absolute() {
+        let s = TemplateSource::LocalAbsolute(PathBuf::from("/abs/t"));
+        assert_eq!(s.display_label(), "/abs/t");
+    }
+    #[test]
+    fn display_label_favorite_wraps_inner() {
+        let s = TemplateSource::Favorite(Box::new(TemplateSource::GithubOwnerRepo {
+            owner: "o".to_owned(),
+            repo: "r".to_owned(),
+        }));
+        assert_eq!(s.display_label(), "favorite → o/r");
+    }
+
+    #[test]
+    fn is_remote_for_each_variant() {
+        assert!(TemplateSource::HostShorthand {
+            host: GitHost::GitHub,
+            owner_repo: "o/r".to_owned()
+        }
+        .is_remote());
+        assert!(TemplateSource::GithubOwnerRepo {
+            owner: "o".to_owned(),
+            repo: "r".to_owned()
+        }
+        .is_remote());
+        assert!(TemplateSource::RemoteUrl("x".to_owned()).is_remote());
+        assert!(!TemplateSource::LocalRelative(PathBuf::from("./t")).is_remote());
+        assert!(!TemplateSource::LocalAbsolute(PathBuf::from("/t")).is_remote());
+        // Favorite delegates to inner
+        assert!(
+            TemplateSource::Favorite(Box::new(TemplateSource::RemoteUrl("x".to_owned())))
+                .is_remote()
+        );
     }
 }

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -34,11 +34,11 @@ pub enum TemplateSource {
     RemoteUrl(String),
     LocalRelative(PathBuf),
     LocalAbsolute(PathBuf),
-    Favorite(Box<TemplateSource>),
+    Favorite(Box<Self>),
 }
 
 impl GitHost {
-    pub fn to_url(&self, owner_repo: &str) -> String {
+    pub fn to_url(self, owner_repo: &str) -> String {
         match self {
             Self::GitHub => format!("https://github.com/{owner_repo}.git"),
             Self::GitLab => format!("https://gitlab.com/{owner_repo}.git"),
@@ -103,11 +103,7 @@ fn parse_owner_repo(s: &str) -> Option<(String, String)> {
     let repo_ok = repo
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'));
-    if owner_ok && repo_ok {
-        Some((owner.to_owned(), repo.to_owned()))
-    } else {
-        None
-    }
+    (owner_ok && repo_ok).then(|| (owner.to_owned(), repo.to_owned()))
 }
 
 impl TemplateSource {
@@ -180,6 +176,7 @@ impl TemplateSource {
 
     /// User-facing label preserving the form the user typed. Used in
     /// warnings, log lines, error messages.
+    #[allow(dead_code)]
     pub fn display_label(&self) -> std::borrow::Cow<'_, str> {
         use std::borrow::Cow;
         match self {
@@ -252,6 +249,7 @@ impl TemplateSource {
 
     /// Whether this source should be acquired by cloning vs copying.
     /// Favorites delegate to their inner source.
+    #[allow(dead_code)]
     pub fn is_remote(&self) -> bool {
         match self {
             Self::HostShorthand { .. } | Self::GithubOwnerRepo { .. } | Self::RemoteUrl(_) => true,

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -306,11 +306,15 @@ mod tests {
 
     #[test]
     fn classify_absolute_path() {
-        let s = TemplateSource::classify("/Users/me/template", &empty_config(), Path::new("/tmp"));
-        assert_eq!(
-            s,
-            TemplateSource::LocalAbsolute(PathBuf::from("/Users/me/template"))
-        );
+        // Windows requires a drive letter for `Path::is_absolute()`;
+        // a leading `/` alone is "rooted but not absolute."
+        let input = if cfg!(windows) {
+            r"C:\Users\me\template"
+        } else {
+            "/Users/me/template"
+        };
+        let s = TemplateSource::classify(input, &empty_config(), Path::new("/tmp"));
+        assert_eq!(s, TemplateSource::LocalAbsolute(PathBuf::from(input)));
     }
 
     #[test]
@@ -550,19 +554,22 @@ mod tests {
     #[test]
     fn classify_favorite_with_absolute_path() {
         use std::path::PathBuf;
+        let abs = if cfg!(windows) {
+            r"C:\abs\template"
+        } else {
+            "/abs/template"
+        };
         let cfg = config_with_favorite(
             "myfave",
             FavoriteConfig {
-                path: Some(PathBuf::from("/abs/template")),
+                path: Some(PathBuf::from(abs)),
                 ..FavoriteConfig::default()
             },
         );
         let s = TemplateSource::classify("myfave", &cfg, Path::new("/tmp"));
         assert_eq!(
             s,
-            TemplateSource::Favorite(Box::new(TemplateSource::LocalAbsolute(PathBuf::from(
-                "/abs/template"
-            ))))
+            TemplateSource::Favorite(Box::new(TemplateSource::LocalAbsolute(PathBuf::from(abs))))
         );
     }
 

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -1,6 +1,5 @@
 //! Classified template source: where the template comes from, validated
-//! at construction time. See
-//! `docs/superpowers/specs/2026-05-20-template-source-classifier-design.md`.
+//! at construction time.
 
 use std::path::PathBuf;
 

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -228,6 +228,23 @@ impl TemplateSource {
         }
     }
 
+    /// Like `into_template_location` but forces local paths through git clone.
+    /// Used by the `--git` flag, which means "use git even for local paths"
+    /// so that branch/tag/ssh-identity options are honoured.
+    pub fn into_git_template_location(
+        self,
+        clone_opts: &CloneOptions,
+    ) -> crate::user_parsed_input::TemplateLocation {
+        use crate::user_parsed_input::{GitUserInput, TemplateLocation};
+        match self {
+            Self::LocalAbsolute(p) | Self::LocalRelative(p) => TemplateLocation::Git(
+                GitUserInput::with_url_and_clone_opts(p.display().to_string(), clone_opts),
+            ),
+            Self::Favorite(inner) => inner.into_git_template_location(clone_opts),
+            other => other.into_template_location(clone_opts),
+        }
+    }
+
     #[cfg(test)]
     fn into_template_location_for_test(self) -> crate::user_parsed_input::TemplateLocation {
         self.into_template_location(&CloneOptions::default())

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -35,6 +35,19 @@ impl GitHost {
     }
 }
 
+fn strip_host_prefix(s: &str) -> Option<(GitHost, &str)> {
+    let prefix = s.get(..3)?;
+    let rest = s.get(3..)?;
+    let host = match prefix {
+        "gh:" => GitHost::GitHub,
+        "gl:" => GitHost::GitLab,
+        "bb:" => GitHost::Bitbucket,
+        "sr:" => GitHost::SourceHut,
+        _ => return None,
+    };
+    Some((host, rest))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,5 +82,34 @@ mod tests {
             GitHost::SourceHut.to_url("user/repo"),
             "https://git.sr.ht/~user/repo"
         );
+    }
+
+    #[test]
+    fn strip_host_prefix_recognizes_gh() {
+        assert_eq!(strip_host_prefix("gh:o/r"), Some((GitHost::GitHub, "o/r")));
+    }
+    #[test]
+    fn strip_host_prefix_recognizes_gl() {
+        assert_eq!(strip_host_prefix("gl:o/r"), Some((GitHost::GitLab, "o/r")));
+    }
+    #[test]
+    fn strip_host_prefix_recognizes_bb() {
+        assert_eq!(strip_host_prefix("bb:o/r"), Some((GitHost::Bitbucket, "o/r")));
+    }
+    #[test]
+    fn strip_host_prefix_recognizes_sr() {
+        assert_eq!(strip_host_prefix("sr:u/r"), Some((GitHost::SourceHut, "u/r")));
+    }
+    #[test]
+    fn strip_host_prefix_rejects_unknown_prefix() {
+        assert_eq!(strip_host_prefix("xx:o/r"), None);
+    }
+    #[test]
+    fn strip_host_prefix_rejects_short_input() {
+        assert_eq!(strip_host_prefix("gh"), None);
+    }
+    #[test]
+    fn strip_host_prefix_rejects_bare_owner_repo() {
+        assert_eq!(strip_host_prefix("owner/repo"), None);
     }
 }

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -97,9 +97,168 @@ fn parse_owner_repo(s: &str) -> Option<(String, String)> {
     }
 }
 
+impl TemplateSource {
+    /// Classify a raw template input into a `TemplateSource`. See the
+    /// design doc for the precedence rules; ordering here is intentional.
+    pub fn classify(
+        input: &str,
+        app_config: &crate::app_config::AppConfig,
+        cwd: &std::path::Path,
+    ) -> Self {
+        Self::classify_with_depth(input, app_config, cwd, 0)
+    }
+
+    fn classify_with_depth(
+        input: &str,
+        app_config: &crate::app_config::AppConfig,
+        cwd: &std::path::Path,
+        depth: u8,
+    ) -> Self {
+        const FAVORITE_RECURSION_LIMIT: u8 = 8;
+
+        // 1. Configured favorite name (only when within recursion budget).
+        if depth <= FAVORITE_RECURSION_LIMIT {
+            if let Some(fav) = app_config.get_favorite_cfg(input) {
+                let inner = if let Some(git) = fav.git.as_deref() {
+                    Self::classify_with_depth(git, app_config, cwd, depth + 1)
+                } else if let Some(p) = fav.path.as_ref() {
+                    if p.is_absolute() {
+                        Self::LocalAbsolute(p.clone())
+                    } else {
+                        Self::LocalRelative(cwd.join(p))
+                    }
+                } else {
+                    Self::RemoteUrl(input.to_owned())
+                };
+                return Self::Favorite(Box::new(inner));
+            }
+        }
+
+        // 2. Host prefix
+        if let Some((host, rest)) = strip_host_prefix(input) {
+            return Self::HostShorthand {
+                host,
+                owner_repo: rest.to_owned(),
+            };
+        }
+        // 3. Full URL
+        if looks_like_url(input) {
+            return Self::RemoteUrl(input.to_owned());
+        }
+        // 4. Absolute path
+        let p = std::path::Path::new(input);
+        if p.is_absolute() {
+            return Self::LocalAbsolute(p.to_path_buf());
+        }
+        // 5. Relative path that exists as a directory
+        let resolved = cwd.join(p);
+        if resolved.is_dir() {
+            return Self::LocalRelative(resolved);
+        }
+        // 6. Bare owner/repo → github
+        if let Some((owner, repo)) = parse_owner_repo(input) {
+            return Self::GithubOwnerRepo { owner, repo };
+        }
+        // 7. Catch-all — let git produce the clearer error.
+        Self::RemoteUrl(input.to_owned())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app_config::AppConfig;
+    use std::path::Path;
+
+    fn empty_config() -> AppConfig {
+        AppConfig::default()
+    }
+
+    #[test]
+    fn classify_host_shorthand() {
+        let s = TemplateSource::classify("gh:owner/repo", &empty_config(), Path::new("/tmp"));
+        assert_eq!(
+            s,
+            TemplateSource::HostShorthand {
+                host: GitHost::GitHub,
+                owner_repo: "owner/repo".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn classify_https_url() {
+        let s = TemplateSource::classify(
+            "https://github.com/owner/repo.git",
+            &empty_config(),
+            Path::new("/tmp"),
+        );
+        assert_eq!(
+            s,
+            TemplateSource::RemoteUrl("https://github.com/owner/repo.git".to_owned())
+        );
+    }
+
+    #[test]
+    fn classify_scp_url() {
+        let s = TemplateSource::classify(
+            "git@github.com:owner/repo.git",
+            &empty_config(),
+            Path::new("/tmp"),
+        );
+        assert_eq!(
+            s,
+            TemplateSource::RemoteUrl("git@github.com:owner/repo.git".to_owned())
+        );
+    }
+
+    #[test]
+    fn classify_absolute_path() {
+        let s = TemplateSource::classify("/Users/me/template", &empty_config(), Path::new("/tmp"));
+        assert_eq!(
+            s,
+            TemplateSource::LocalAbsolute(PathBuf::from("/Users/me/template"))
+        );
+    }
+
+    #[test]
+    fn classify_existing_relative_dir() {
+        let cwd = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(cwd.path().join("template")).unwrap();
+        let s = TemplateSource::classify("./template", &empty_config(), cwd.path());
+        assert_eq!(s, TemplateSource::LocalRelative(cwd.path().join("template")));
+    }
+
+    #[test]
+    fn classify_owner_repo_when_no_local_dir() {
+        let cwd = tempfile::TempDir::new().unwrap();
+        let s = TemplateSource::classify("owner/repo", &empty_config(), cwd.path());
+        assert_eq!(
+            s,
+            TemplateSource::GithubOwnerRepo {
+                owner: "owner".to_owned(),
+                repo: "repo".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn classify_relative_dir_beats_owner_repo() {
+        let cwd = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(cwd.path().join("owner/repo")).unwrap();
+        let s = TemplateSource::classify("owner/repo", &empty_config(), cwd.path());
+        assert_eq!(
+            s,
+            TemplateSource::LocalRelative(cwd.path().join("owner/repo"))
+        );
+    }
+
+    #[test]
+    fn classify_fallback_to_remote_url() {
+        let cwd = tempfile::TempDir::new().unwrap();
+        let s = TemplateSource::classify("garbage~~~", &empty_config(), cwd.path());
+        assert_eq!(s, TemplateSource::RemoteUrl("garbage~~~".to_owned()));
+    }
 
     #[test]
     fn git_host_to_url_github() {

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -416,4 +416,84 @@ mod tests {
         // verbatim input, NOT wrapped in Favorite.
         assert_eq!(s, TemplateSource::RemoteUrl("just-a-name".to_owned()));
     }
+
+    use crate::app_config::FavoriteConfig;
+    use std::collections::HashMap;
+
+    fn config_with_favorite(name: &str, fav: FavoriteConfig) -> AppConfig {
+        let mut map = HashMap::new();
+        map.insert(name.to_owned(), fav);
+        AppConfig {
+            favorites: Some(map),
+            ..AppConfig::default()
+        }
+    }
+
+    #[test]
+    fn classify_favorite_with_git_string_recurses() {
+        let cfg = config_with_favorite(
+            "myfave",
+            FavoriteConfig {
+                git: Some("gh:owner/repo".to_owned()),
+                ..FavoriteConfig::default()
+            },
+        );
+        let s = TemplateSource::classify("myfave", &cfg, Path::new("/tmp"));
+        assert_eq!(
+            s,
+            TemplateSource::Favorite(Box::new(TemplateSource::HostShorthand {
+                host: GitHost::GitHub,
+                owner_repo: "owner/repo".to_owned(),
+            }))
+        );
+    }
+
+    #[test]
+    fn classify_favorite_with_absolute_path() {
+        use std::path::PathBuf;
+        let cfg = config_with_favorite(
+            "myfave",
+            FavoriteConfig {
+                path: Some(PathBuf::from("/abs/template")),
+                ..FavoriteConfig::default()
+            },
+        );
+        let s = TemplateSource::classify("myfave", &cfg, Path::new("/tmp"));
+        assert_eq!(
+            s,
+            TemplateSource::Favorite(Box::new(TemplateSource::LocalAbsolute(
+                PathBuf::from("/abs/template")
+            )))
+        );
+    }
+
+    #[test]
+    fn classify_favorite_cycle_bounded_falls_back() {
+        // Two favorites pointing at each other; cycle bound prevents
+        // infinite recursion. After the depth limit we stop following
+        // favorites and the last name is treated as a non-favorite.
+        let mut map = HashMap::new();
+        map.insert(
+            "a".to_owned(),
+            FavoriteConfig {
+                git: Some("b".to_owned()),
+                ..FavoriteConfig::default()
+            },
+        );
+        map.insert(
+            "b".to_owned(),
+            FavoriteConfig {
+                git: Some("a".to_owned()),
+                ..FavoriteConfig::default()
+            },
+        );
+        let cfg = AppConfig {
+            favorites: Some(map),
+            ..AppConfig::default()
+        };
+        let s = TemplateSource::classify("a", &cfg, Path::new("/tmp"));
+        // The exact deep structure doesn't matter; what matters is that
+        // classify terminates and produces something well-formed.
+        assert!(matches!(s, TemplateSource::Favorite(_)));
+    }
 }

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -4,6 +4,19 @@
 
 use std::path::PathBuf;
 
+/// Options threaded into git clones for remote sources. Local sources
+/// ignore these. Used by `TemplateSource::into_template_location`.
+#[derive(Debug, Clone, Default)]
+pub struct CloneOptions {
+    pub branch: Option<String>,
+    pub tag: Option<String>,
+    pub revision: Option<String>,
+    pub ssh_identity: Option<PathBuf>,
+    pub gitconfig: Option<PathBuf>,
+    pub force_git_init: bool,
+    pub skip_submodules: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum GitHost {
@@ -186,6 +199,38 @@ impl TemplateSource {
             }
             Self::Favorite(inner) => Cow::Owned(format!("favorite → {}", inner.display_label())),
         }
+    }
+
+    /// Adapter producing the legacy `TemplateLocation`. `clone_opts` are
+    /// threaded through to `GitUserInput::new` for remote variants;
+    /// ignored for local variants. Once consumers migrate, this method
+    /// goes away.
+    pub fn into_template_location(
+        self,
+        clone_opts: &CloneOptions,
+    ) -> crate::user_parsed_input::TemplateLocation {
+        use crate::user_parsed_input::{GitUserInput, TemplateLocation};
+        match self {
+            Self::HostShorthand { host, owner_repo } => TemplateLocation::Git(
+                GitUserInput::with_url_and_clone_opts(host.to_url(&owner_repo), clone_opts),
+            ),
+            Self::GithubOwnerRepo { owner, repo } => TemplateLocation::Git(
+                GitUserInput::with_url_and_clone_opts(
+                    format!("https://github.com/{owner}/{repo}.git"),
+                    clone_opts,
+                ),
+            ),
+            Self::RemoteUrl(url) => TemplateLocation::Git(
+                GitUserInput::with_url_and_clone_opts(url, clone_opts),
+            ),
+            Self::LocalAbsolute(p) | Self::LocalRelative(p) => TemplateLocation::Path(p),
+            Self::Favorite(inner) => inner.into_template_location(clone_opts),
+        }
+    }
+
+    #[cfg(test)]
+    fn into_template_location_for_test(self) -> crate::user_parsed_input::TemplateLocation {
+        self.into_template_location(&CloneOptions::default())
     }
 
     /// Whether this source should be acquired by cloning vs copying.
@@ -568,6 +613,47 @@ mod tests {
             repo: "r".to_owned(),
         }));
         assert_eq!(s.display_label(), "favorite → o/r");
+    }
+
+    use crate::user_parsed_input::TemplateLocation;
+
+    #[test]
+    fn into_template_location_maps_host_shorthand_to_git_url() {
+        let s = TemplateSource::HostShorthand {
+            host: GitHost::GitHub,
+            owner_repo: "o/r".to_owned(),
+        };
+        match s.into_template_location_for_test() {
+            TemplateLocation::Git(g) => assert_eq!(g.url(), "https://github.com/o/r.git"),
+            TemplateLocation::Path(_) => panic!("expected Git"),
+        }
+    }
+    #[test]
+    fn into_template_location_maps_owner_repo_to_git_url() {
+        let s = TemplateSource::GithubOwnerRepo {
+            owner: "o".to_owned(),
+            repo: "r".to_owned(),
+        };
+        match s.into_template_location_for_test() {
+            TemplateLocation::Git(g) => assert_eq!(g.url(), "https://github.com/o/r.git"),
+            TemplateLocation::Path(_) => panic!("expected Git"),
+        }
+    }
+    #[test]
+    fn into_template_location_maps_remote_url_verbatim() {
+        let s = TemplateSource::RemoteUrl("ssh://git@x/y.git".to_owned());
+        match s.into_template_location_for_test() {
+            TemplateLocation::Git(g) => assert_eq!(g.url(), "ssh://git@x/y.git"),
+            TemplateLocation::Path(_) => panic!("expected Git"),
+        }
+    }
+    #[test]
+    fn into_template_location_maps_local_to_path() {
+        let s = TemplateSource::LocalAbsolute(PathBuf::from("/abs"));
+        match s.into_template_location_for_test() {
+            TemplateLocation::Path(p) => assert_eq!(p, Path::new("/abs")),
+            TemplateLocation::Git(_) => panic!("expected Path"),
+        }
     }
 
     #[test]

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -210,7 +210,7 @@ impl TemplateSource {
             ),
             Self::GithubOwnerRepo { owner, repo } => {
                 TemplateLocation::Git(GitUserInput::with_url_and_clone_opts(
-                    format!("https://github.com/{owner}/{repo}.git"),
+                    GitHost::GitHub.to_url(&format!("{owner}/{repo}")),
                     clone_opts,
                 ))
             }

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -23,3 +23,51 @@ pub enum TemplateSource {
     LocalAbsolute(PathBuf),
     Favorite(Box<TemplateSource>),
 }
+
+impl GitHost {
+    pub fn to_url(&self, owner_repo: &str) -> String {
+        match self {
+            Self::GitHub => format!("https://github.com/{owner_repo}.git"),
+            Self::GitLab => format!("https://gitlab.com/{owner_repo}.git"),
+            Self::Bitbucket => format!("https://bitbucket.org/{owner_repo}.git"),
+            Self::SourceHut => format!("https://git.sr.ht/~{owner_repo}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn git_host_to_url_github() {
+        assert_eq!(
+            GitHost::GitHub.to_url("owner/repo"),
+            "https://github.com/owner/repo.git"
+        );
+    }
+
+    #[test]
+    fn git_host_to_url_gitlab() {
+        assert_eq!(
+            GitHost::GitLab.to_url("owner/repo"),
+            "https://gitlab.com/owner/repo.git"
+        );
+    }
+
+    #[test]
+    fn git_host_to_url_bitbucket() {
+        assert_eq!(
+            GitHost::Bitbucket.to_url("owner/repo"),
+            "https://bitbucket.org/owner/repo.git"
+        );
+    }
+
+    #[test]
+    fn git_host_to_url_sourcehut_inserts_tilde() {
+        assert_eq!(
+            GitHost::SourceHut.to_url("user/repo"),
+            "https://git.sr.ht/~user/repo"
+        );
+    }
+}

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -1,0 +1,25 @@
+//! Classified template source: where the template comes from, validated
+//! at construction time. See
+//! `docs/superpowers/specs/2026-05-20-template-source-classifier-design.md`.
+
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GitHost {
+    GitHub,
+    GitLab,
+    Bitbucket,
+    SourceHut,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TemplateSource {
+    HostShorthand { host: GitHost, owner_repo: String },
+    GithubOwnerRepo { owner: String, repo: String },
+    RemoteUrl(String),
+    LocalRelative(PathBuf),
+    LocalAbsolute(PathBuf),
+    Favorite(Box<TemplateSource>),
+}

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -48,6 +48,29 @@ fn strip_host_prefix(s: &str) -> Option<(GitHost, &str)> {
     Some((host, rest))
 }
 
+fn looks_like_url(s: &str) -> bool {
+    if s.starts_with("https://")
+        || s.starts_with("http://")
+        || s.starts_with("ssh://")
+        || s.starts_with("git://")
+        || s.starts_with("file://")
+    {
+        return true;
+    }
+    // scp-style `git@host:path`: a `user@host:rest` form where the colon
+    // is BEFORE the first slash (URLs and paths put `/` before `:`).
+    if let Some(at) = s.find('@') {
+        if let Some(colon_offset) = s[at..].find(':') {
+            let colon = at + colon_offset;
+            let slash = s.find('/').unwrap_or(s.len());
+            if colon < slash {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,5 +134,42 @@ mod tests {
     #[test]
     fn strip_host_prefix_rejects_bare_owner_repo() {
         assert_eq!(strip_host_prefix("owner/repo"), None);
+    }
+
+    #[test]
+    fn looks_like_url_https() {
+        assert!(looks_like_url("https://github.com/owner/repo.git"));
+    }
+    #[test]
+    fn looks_like_url_http() {
+        assert!(looks_like_url("http://example.com/repo.git"));
+    }
+    #[test]
+    fn looks_like_url_ssh_scheme() {
+        assert!(looks_like_url("ssh://git@github.com/owner/repo.git"));
+    }
+    #[test]
+    fn looks_like_url_git_scheme() {
+        assert!(looks_like_url("git://github.com/owner/repo.git"));
+    }
+    #[test]
+    fn looks_like_url_scp_style() {
+        assert!(looks_like_url("git@github.com:owner/repo.git"));
+    }
+    #[test]
+    fn looks_like_url_rejects_owner_repo() {
+        assert!(!looks_like_url("owner/repo"));
+    }
+    #[test]
+    fn looks_like_url_rejects_relative_path() {
+        assert!(!looks_like_url("./template"));
+    }
+    #[test]
+    fn looks_like_url_rejects_absolute_path() {
+        assert!(!looks_like_url("/Users/me/template"));
+    }
+    #[test]
+    fn looks_like_url_rejects_host_prefix() {
+        assert!(!looks_like_url("gh:owner/repo"));
     }
 }

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -191,9 +191,7 @@ impl TemplateSource {
             }
             Self::GithubOwnerRepo { owner, repo } => Cow::Owned(format!("{owner}/{repo}")),
             Self::RemoteUrl(url) => Cow::Borrowed(url.as_str()),
-            Self::LocalRelative(p) | Self::LocalAbsolute(p) => {
-                Cow::Owned(p.display().to_string())
-            }
+            Self::LocalRelative(p) | Self::LocalAbsolute(p) => Cow::Owned(p.display().to_string()),
             Self::Favorite(inner) => Cow::Owned(format!("favorite → {}", inner.display_label())),
         }
     }
@@ -211,15 +209,15 @@ impl TemplateSource {
             Self::HostShorthand { host, owner_repo } => TemplateLocation::Git(
                 GitUserInput::with_url_and_clone_opts(host.to_url(&owner_repo), clone_opts),
             ),
-            Self::GithubOwnerRepo { owner, repo } => TemplateLocation::Git(
-                GitUserInput::with_url_and_clone_opts(
+            Self::GithubOwnerRepo { owner, repo } => {
+                TemplateLocation::Git(GitUserInput::with_url_and_clone_opts(
                     format!("https://github.com/{owner}/{repo}.git"),
                     clone_opts,
-                ),
-            ),
-            Self::RemoteUrl(url) => TemplateLocation::Git(
-                GitUserInput::with_url_and_clone_opts(url, clone_opts),
-            ),
+                ))
+            }
+            Self::RemoteUrl(url) => {
+                TemplateLocation::Git(GitUserInput::with_url_and_clone_opts(url, clone_opts))
+            }
             Self::LocalAbsolute(p) | Self::LocalRelative(p) => TemplateLocation::Path(p),
             Self::Favorite(inner) => inner.into_template_location(clone_opts),
         }
@@ -321,7 +319,10 @@ mod tests {
         let cwd = tempfile::TempDir::new().unwrap();
         std::fs::create_dir_all(cwd.path().join("template")).unwrap();
         let s = TemplateSource::classify("./template", &empty_config(), cwd.path());
-        assert_eq!(s, TemplateSource::LocalRelative(cwd.path().join("template")));
+        assert_eq!(
+            s,
+            TemplateSource::LocalRelative(cwd.path().join("template"))
+        );
     }
 
     #[test]
@@ -397,11 +398,17 @@ mod tests {
     }
     #[test]
     fn strip_host_prefix_recognizes_bb() {
-        assert_eq!(strip_host_prefix("bb:o/r"), Some((GitHost::Bitbucket, "o/r")));
+        assert_eq!(
+            strip_host_prefix("bb:o/r"),
+            Some((GitHost::Bitbucket, "o/r"))
+        );
     }
     #[test]
     fn strip_host_prefix_recognizes_sr() {
-        assert_eq!(strip_host_prefix("sr:u/r"), Some((GitHost::SourceHut, "u/r")));
+        assert_eq!(
+            strip_host_prefix("sr:u/r"),
+            Some((GitHost::SourceHut, "u/r"))
+        );
     }
     #[test]
     fn strip_host_prefix_rejects_unknown_prefix() {
@@ -554,9 +561,9 @@ mod tests {
         let s = TemplateSource::classify("myfave", &cfg, Path::new("/tmp"));
         assert_eq!(
             s,
-            TemplateSource::Favorite(Box::new(TemplateSource::LocalAbsolute(
-                PathBuf::from("/abs/template")
-            )))
+            TemplateSource::Favorite(Box::new(TemplateSource::LocalAbsolute(PathBuf::from(
+                "/abs/template"
+            ))))
         );
     }
 

--- a/src/template_source.rs
+++ b/src/template_source.rs
@@ -71,6 +71,32 @@ fn looks_like_url(s: &str) -> bool {
     false
 }
 
+fn parse_owner_repo(s: &str) -> Option<(String, String)> {
+    // Require exactly one `/`, both sides nonempty, owner side doesn't
+    // start with `.` (which would be a relative path form).
+    let (owner, repo) = s.split_once('/')?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    if repo.contains('/') {
+        return None;
+    }
+    if owner.starts_with('.') {
+        return None;
+    }
+    let owner_ok = owner
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'));
+    let repo_ok = repo
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'));
+    if owner_ok && repo_ok {
+        Some((owner.to_owned(), repo.to_owned()))
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,5 +197,44 @@ mod tests {
     #[test]
     fn looks_like_url_rejects_host_prefix() {
         assert!(!looks_like_url("gh:owner/repo"));
+    }
+
+    #[test]
+    fn parse_owner_repo_simple() {
+        assert_eq!(
+            parse_owner_repo("owner/repo"),
+            Some(("owner".to_owned(), "repo".to_owned()))
+        );
+    }
+    #[test]
+    fn parse_owner_repo_with_dashes_and_dots() {
+        assert_eq!(
+            parse_owner_repo("my-org/my.repo"),
+            Some(("my-org".to_owned(), "my.repo".to_owned()))
+        );
+    }
+    #[test]
+    fn parse_owner_repo_rejects_relative_dot_prefix() {
+        assert_eq!(parse_owner_repo("./path"), None);
+    }
+    #[test]
+    fn parse_owner_repo_rejects_double_dot() {
+        assert_eq!(parse_owner_repo("../path"), None);
+    }
+    #[test]
+    fn parse_owner_repo_rejects_three_segments() {
+        assert_eq!(parse_owner_repo("a/b/c"), None);
+    }
+    #[test]
+    fn parse_owner_repo_rejects_leading_slash() {
+        assert_eq!(parse_owner_repo("/abs/path"), None);
+    }
+    #[test]
+    fn parse_owner_repo_rejects_trailing_slash() {
+        assert_eq!(parse_owner_repo("owner/"), None);
+    }
+    #[test]
+    fn parse_owner_repo_rejects_no_slash() {
+        assert_eq!(parse_owner_repo("ownerrepo"), None);
     }
 }

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -8,7 +8,6 @@ use std::{
 
 use crate::absolute_path::AbsolutePathExt;
 use console::style;
-use regex::Regex;
 
 use crate::{app_config::AppConfig, template_variables::CrateType, GenerateArgs, Vcs};
 use log::warn;
@@ -363,38 +362,6 @@ impl UserParsedInput {
     }
 }
 
-/// favorite can be in form with abbreviation what means that input is git repository
-/// if so, the 3rd character would be a semicolon
-pub fn abbreviated_git_url_to_full_remote(git: impl AsRef<str>) -> Option<String> {
-    let git = git.as_ref();
-    if git.len() >= 3 {
-        match &git[..3] {
-            "gl:" => Some(format!("https://gitlab.com/{}.git", &git[3..])),
-            "bb:" => Some(format!("https://bitbucket.org/{}.git", &git[3..])),
-            "gh:" => Some(format!("https://github.com/{}.git", &git[3..])),
-            "sr:" => Some(format!("https://git.sr.ht/~{}", &git[3..])),
-            _ => None,
-        }
-    } else {
-        None
-    }
-}
-
-fn is_abbreviated_github(fav: &str) -> bool {
-    let org_repo_regex = Regex::new(r"^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_%-]+$").unwrap();
-    org_repo_regex.is_match(fav)
-}
-
-// favorite can be in form of org/repo what should be parsed as github.com
-pub fn abbreviated_github(fav: &str) -> Option<String> {
-    is_abbreviated_github(fav).then(|| format!("https://github.com/{fav}.git"))
-}
-
-pub fn local_path(fav: &str) -> Option<PathBuf> {
-    let path = PathBuf::from(fav);
-    (path.exists() && path.is_dir()).then_some(path)
-}
-
 // Template should be cloned with git
 #[derive(Debug)]
 pub struct GitUserInput {
@@ -450,20 +417,6 @@ impl GitUserInput {
         )
     }
 
-    // when git was used as abbreviation but other flags still could be passed
-    fn with_git_url_and_args(url: &impl AsRef<str>, args: &GenerateArgs) -> Self {
-        Self::new(
-            url,
-            args.template_path.branch(),
-            args.template_path.tag(),
-            args.template_path.revision(),
-            args.ssh_identity.clone(),
-            args.gitconfig.clone(),
-            args.force_git_init,
-            args.skip_submodules,
-        )
-    }
-
     pub fn url(&self) -> &str {
         self.url.as_ref()
     }
@@ -514,36 +467,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn should_support_colon_abbreviations() {
-        assert_eq!(
-            &abbreviated_git_url_to_full_remote("gh:foo/bar").unwrap(),
-            "https://github.com/foo/bar.git"
-        );
-        assert_eq!(
-            &abbreviated_git_url_to_full_remote("bb:foo/bar").unwrap(),
-            "https://bitbucket.org/foo/bar.git"
-        );
-        assert_eq!(
-            &abbreviated_git_url_to_full_remote("gl:foo/bar").unwrap(),
-            "https://gitlab.com/foo/bar.git"
-        );
-        assert_eq!(
-            &abbreviated_git_url_to_full_remote("sr:foo/bar").unwrap(),
-            "https://git.sr.ht/~foo/bar"
-        );
-        assert!(&abbreviated_git_url_to_full_remote("foo/bar").is_none());
-    }
-
-    #[test]
-    fn should_appreviation_org_repo_to_github() {
-        assert_eq!(
-            &abbreviated_github("org/repo").unwrap(),
-            "https://github.com/org/repo.git"
-        );
-        assert!(&abbreviated_github("path/to/a/sth").is_none());
-    }
 
     /// Helper to build a `GenerateArgs` with `--git <value>` and resolve via `try_from_args_and_config`,
     /// returning the resolved git URL from the resulting `TemplateLocation`.

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -457,6 +457,24 @@ impl GitUserInput {
         }
     }
 
+    /// Build a `GitUserInput` from a resolved URL and the cargo-generate
+    /// clone options. Used by `TemplateSource::into_template_location`.
+    pub fn with_url_and_clone_opts(
+        url: String,
+        opts: &crate::template_source::CloneOptions,
+    ) -> Self {
+        Self::new(
+            &url,
+            opts.branch.as_ref(),
+            opts.tag.as_ref(),
+            opts.revision.as_ref(),
+            opts.ssh_identity.clone(),
+            opts.gitconfig.clone(),
+            opts.force_git_init,
+            opts.skip_submodules,
+        )
+    }
+
     // when git was used as abbreviation but other flags still could be passed
     fn with_git_url_and_args(url: &impl AsRef<str>, args: &GenerateArgs) -> Self {
         Self::new(

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -118,33 +118,25 @@ impl UserParsedInput {
 
         // --git
         if let Some(git_url) = args.template_path.git() {
-            let resolved_url = abbreviated_git_url_to_full_remote(git_url.as_ref())
-                .or_else(|| {
-                    // Only try org/repo → github expansion when the value isn't a local path
-                    if local_path(git_url.as_ref()).is_none() {
-                        abbreviated_github(git_url.as_ref())
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or_else(|| git_url.as_ref().to_owned());
-            let git_user_in = GitUserInput::new(
-                &resolved_url,
-                args.template_path.branch(),
-                args.template_path.tag(),
-                args.template_path.revision(),
-                ssh_identity,
-                args.gitconfig.clone(),
-                args.force_git_init,
-                args.skip_submodules,
+            let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
+            let source = crate::template_source::TemplateSource::classify(
+                git_url.as_ref(),
+                &app_config,
+                &cwd,
             );
+            let clone_opts = crate::template_source::CloneOptions {
+                branch: args.template_path.branch().map(|s| s.as_ref().to_owned()),
+                tag: args.template_path.tag().map(|s| s.as_ref().to_owned()),
+                revision: args.template_path.revision().map(|s| s.as_ref().to_owned()),
+                ssh_identity: ssh_identity.clone(),
+                gitconfig: args.gitconfig.clone(),
+                force_git_init: args.force_git_init,
+                skip_submodules: args.skip_submodules,
+            };
             return Self {
                 name: args.name.clone(),
-                template_location: git_user_in.into(),
-                subfolder: args
-                    .template_path
-                    .subfolder()
-                    .map(|s| s.as_ref().to_owned()),
+                template_location: source.into_git_template_location(&clone_opts),
+                subfolder: args.template_path.subfolder().map(|s| s.as_ref().to_owned()),
                 template_values: default_values,
                 vcs: args.vcs.unwrap_or(DEFAULT_VCS),
                 init: args.init,
@@ -645,8 +637,9 @@ mod tests {
     #[test]
     fn git_flag_relative_path_resolves_to_local_directory() {
         // When --git receives a relative path like `./example-templates/hooks`
-        // that exists as a local directory, it must be kept as-is rather than
-        // being interpreted as a remote URL or expanded to github.
+        // that exists as a local directory, it must remain a Git location so
+        // that branch/tag/ssh-identity options are honoured (git clone accepts
+        // file-system paths). It must NOT be expanded to a remote URL.
         // `cargo test` sets cwd to the crate root, so this path resolves.
         let args = GenerateArgs {
             template_path: crate::TemplatePath {
@@ -660,7 +653,11 @@ mod tests {
 
         match parsed.location() {
             TemplateLocation::Git(git) => {
-                assert_eq!(git.url(), "./example-templates/hooks")
+                assert!(
+                    git.url().ends_with("example-templates/hooks"),
+                    "expected url ending in example-templates/hooks, got {}",
+                    git.url()
+                );
             }
             TemplateLocation::Path(p) => panic!("expected Git location, got Path: {p:?}"),
         }
@@ -669,8 +666,8 @@ mod tests {
     #[test]
     fn git_flag_local_path_takes_precedence_over_org_repo() {
         // When --git receives a value matching the org/repo shape that also
-        // exists as a local directory, it must be kept as-is rather than
-        // expanded to github. `example-templates/hooks` doubles as a real
+        // exists as a local directory, it must be kept as a Git location rather
+        // than expanded to github. `example-templates/hooks` doubles as a real
         // path under the crate root and a valid `org/repo` shape.
         let args = GenerateArgs {
             template_path: crate::TemplatePath {
@@ -682,7 +679,13 @@ mod tests {
 
         let parsed = UserParsedInput::try_from_args_and_config(AppConfig::default(), &args);
         match parsed.location() {
-            TemplateLocation::Git(git) => assert_eq!(git.url(), "example-templates/hooks"),
+            TemplateLocation::Git(git) => {
+                assert!(
+                    git.url().ends_with("example-templates/hooks"),
+                    "expected url ending in example-templates/hooks, got {}",
+                    git.url()
+                );
+            }
             TemplateLocation::Path(p) => panic!("expected Git location, got Path: {p:?}"),
         }
     }

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -626,57 +626,45 @@ mod tests {
 
     #[test]
     fn git_flag_relative_path_resolves_to_local_directory() {
-        // When --git receives a relative path like `./path` that exists as a
-        // local directory, it must be kept as-is rather than being interpreted
-        // as a remote URL or expanded to github.
-        let workspace = tempfile::TempDir::new().unwrap();
-        std::fs::create_dir_all(workspace.path().join("path")).unwrap();
-
+        // When --git receives a relative path like `./example-templates/hooks`
+        // that exists as a local directory, it must be kept as-is rather than
+        // being interpreted as a remote URL or expanded to github.
+        // `cargo test` sets cwd to the crate root, so this path resolves.
         let args = GenerateArgs {
-            destination: Some(workspace.path().to_path_buf()),
             template_path: crate::TemplatePath {
-                git: Some("./path".to_owned()),
+                git: Some("./example-templates/hooks".to_owned()),
                 ..crate::TemplatePath::default()
             },
             ..GenerateArgs::default()
         };
 
-        // set cwd so that local_path("./path") finds the directory
-        std::env::set_current_dir(workspace.path()).unwrap();
         let parsed = UserParsedInput::try_from_args_and_config(AppConfig::default(), &args);
-        // restore to a known-good directory (avoids poisoning other tests)
-        std::env::set_current_dir(std::env::temp_dir()).unwrap();
 
         match parsed.location() {
-            TemplateLocation::Git(git) => assert_eq!(git.url(), "./path"),
+            TemplateLocation::Git(git) => {
+                assert_eq!(git.url(), "./example-templates/hooks")
+            }
             TemplateLocation::Path(p) => panic!("expected Git location, got Path: {p:?}"),
         }
     }
 
     #[test]
     fn git_flag_local_path_takes_precedence_over_org_repo() {
-        // When --git receives a value matching org/repo that also exists as a
-        // local directory, it must be kept as-is rather than expanded to github.
-        let workspace = tempfile::TempDir::new().unwrap();
-        std::fs::create_dir_all(workspace.path().join("myorg/myrepo")).unwrap();
-
+        // When --git receives a value matching the org/repo shape that also
+        // exists as a local directory, it must be kept as-is rather than
+        // expanded to github. `example-templates/hooks` doubles as a real
+        // path under the crate root and a valid `org/repo` shape.
         let args = GenerateArgs {
-            destination: Some(workspace.path().to_path_buf()),
             template_path: crate::TemplatePath {
-                git: Some("myorg/myrepo".to_owned()),
+                git: Some("example-templates/hooks".to_owned()),
                 ..crate::TemplatePath::default()
             },
             ..GenerateArgs::default()
         };
 
-        // set cwd so that local_path("myorg/myrepo") finds the directory
-        std::env::set_current_dir(workspace.path()).unwrap();
         let parsed = UserParsedInput::try_from_args_and_config(AppConfig::default(), &args);
-        // restore to a known-good directory (avoids poisoning other tests)
-        std::env::set_current_dir(std::env::temp_dir()).unwrap();
-
         match parsed.location() {
-            TemplateLocation::Git(git) => assert_eq!(git.url(), "myorg/myrepo"),
+            TemplateLocation::Git(git) => assert_eq!(git.url(), "example-templates/hooks"),
             TemplateLocation::Path(p) => panic!("expected Git location, got Path: {p:?}"),
         }
     }

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -398,9 +398,6 @@ pub fn abbreviated_git_url_to_full_remote(git: impl AsRef<str>) -> Option<String
             "bb:" => Some(format!("https://bitbucket.org/{}.git", &git[3..])),
             "gh:" => Some(format!("https://github.com/{}.git", &git[3..])),
             "sr:" => Some(format!("https://git.sr.ht/~{}", &git[3..])),
-            short_cut_maybe if is_abbreviated_github(short_cut_maybe) => {
-                Some(format!("https://github.com/{short_cut_maybe}.git"))
-            }
             _ => None,
         }
     } else {
@@ -625,6 +622,35 @@ mod tests {
             resolve_git_flag("sr:username-on-sourcehut/mytemplate"),
             "https://git.sr.ht/~username-on-sourcehut/mytemplate"
         );
+    }
+
+    #[test]
+    fn git_flag_relative_path_resolves_to_local_directory() {
+        // When --git receives a relative path like `./path` that exists as a
+        // local directory, it must be kept as-is rather than being interpreted
+        // as a remote URL or expanded to github.
+        let workspace = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(workspace.path().join("path")).unwrap();
+
+        let args = GenerateArgs {
+            destination: Some(workspace.path().to_path_buf()),
+            template_path: crate::TemplatePath {
+                git: Some("./path".to_owned()),
+                ..crate::TemplatePath::default()
+            },
+            ..GenerateArgs::default()
+        };
+
+        // set cwd so that local_path("./path") finds the directory
+        std::env::set_current_dir(workspace.path()).unwrap();
+        let parsed = UserParsedInput::try_from_args_and_config(AppConfig::default(), &args);
+        // restore to a known-good directory (avoids poisoning other tests)
+        std::env::set_current_dir(std::env::temp_dir()).unwrap();
+
+        match parsed.location() {
+            TemplateLocation::Git(git) => assert_eq!(git.url(), "./path"),
+            TemplateLocation::Path(p) => panic!("expected Git location, got Path: {p:?}"),
+        }
     }
 
     #[test]

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -100,6 +100,8 @@ impl UserParsedInput {
             })
             .unwrap_or_else(|| env::current_dir().unwrap_or_else(|_| ".".into()));
 
+        let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
+
         let mut default_values = app_config.values.clone().unwrap_or_default();
 
         let ssh_identity = app_config
@@ -117,21 +119,12 @@ impl UserParsedInput {
 
         // --git
         if let Some(git_url) = args.template_path.git() {
-            let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
             let source = crate::template_source::TemplateSource::classify(
                 git_url.as_ref(),
                 &app_config,
                 &cwd,
             );
-            let clone_opts = crate::template_source::CloneOptions {
-                branch: args.template_path.branch().map(|s| s.as_ref().to_owned()),
-                tag: args.template_path.tag().map(|s| s.as_ref().to_owned()),
-                revision: args.template_path.revision().map(|s| s.as_ref().to_owned()),
-                ssh_identity: ssh_identity.clone(),
-                gitconfig: args.gitconfig.clone(),
-                force_git_init: args.force_git_init,
-                skip_submodules: args.skip_submodules,
-            };
+            let clone_opts = clone_opts_from_args(args, ssh_identity.clone());
             return Self {
                 name: args.name.clone(),
                 template_location: source.into_git_template_location(&clone_opts),
@@ -251,17 +244,8 @@ impl UserParsedInput {
 
         // there is no specified favorite in configuration
         // auto_path with no configured favorite name → classify it
-        let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
         let source = crate::template_source::TemplateSource::classify(fav_name, &app_config, &cwd);
-        let clone_opts = crate::template_source::CloneOptions {
-            branch: args.template_path.branch().map(|s| s.as_ref().to_owned()),
-            tag: args.template_path.tag().map(|s| s.as_ref().to_owned()),
-            revision: args.template_path.revision().map(|s| s.as_ref().to_owned()),
-            ssh_identity,
-            gitconfig: args.gitconfig.clone(),
-            force_git_init: args.force_git_init,
-            skip_submodules: args.skip_submodules,
-        };
+        let clone_opts = clone_opts_from_args(args, ssh_identity);
         let temp_location = source.into_template_location(&clone_opts);
 
         // Print information about what happened (preserve the existing warn!)
@@ -438,6 +422,21 @@ impl GitUserInput {
 
     pub fn gitconfig(&self) -> Option<&Path> {
         self.gitconfig.as_deref()
+    }
+}
+
+fn clone_opts_from_args(
+    args: &GenerateArgs,
+    ssh_identity: Option<PathBuf>,
+) -> crate::template_source::CloneOptions {
+    crate::template_source::CloneOptions {
+        branch: args.template_path.branch().map(|s| s.as_ref().to_owned()),
+        tag: args.template_path.tag().map(|s| s.as_ref().to_owned()),
+        revision: args.template_path.revision().map(|s| s.as_ref().to_owned()),
+        ssh_identity,
+        gitconfig: args.gitconfig.clone(),
+        force_git_init: args.force_git_init,
+        skip_submodules: args.skip_submodules,
     }
 }
 

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -135,7 +135,10 @@ impl UserParsedInput {
             return Self {
                 name: args.name.clone(),
                 template_location: source.into_git_template_location(&clone_opts),
-                subfolder: args.template_path.subfolder().map(|s| s.as_ref().to_owned()),
+                subfolder: args
+                    .template_path
+                    .subfolder()
+                    .map(|s| s.as_ref().to_owned()),
                 template_values: default_values,
                 vcs: args.vcs.unwrap_or(DEFAULT_VCS),
                 init: args.init,
@@ -249,11 +252,7 @@ impl UserParsedInput {
         // there is no specified favorite in configuration
         // auto_path with no configured favorite name → classify it
         let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
-        let source = crate::template_source::TemplateSource::classify(
-            fav_name,
-            &app_config,
-            &cwd,
-        );
+        let source = crate::template_source::TemplateSource::classify(fav_name, &app_config, &cwd);
         let clone_opts = crate::template_source::CloneOptions {
             branch: args.template_path.branch().map(|s| s.as_ref().to_owned()),
             tag: args.template_path.tag().map(|s| s.as_ref().to_owned()),

--- a/src/user_parsed_input.rs
+++ b/src/user_parsed_input.rs
@@ -248,42 +248,25 @@ impl UserParsedInput {
         }
 
         // there is no specified favorite in configuration
-        // this part try to guess what user wanted in order:
+        // auto_path with no configured favorite name → classify it
+        let cwd = env::current_dir().unwrap_or_else(|_| ".".into());
+        let source = crate::template_source::TemplateSource::classify(
+            fav_name,
+            &app_config,
+            &cwd,
+        );
+        let clone_opts = crate::template_source::CloneOptions {
+            branch: args.template_path.branch().map(|s| s.as_ref().to_owned()),
+            tag: args.template_path.tag().map(|s| s.as_ref().to_owned()),
+            revision: args.template_path.revision().map(|s| s.as_ref().to_owned()),
+            ssh_identity,
+            gitconfig: args.gitconfig.clone(),
+            force_git_init: args.force_git_init,
+            skip_submodules: args.skip_submodules,
+        };
+        let temp_location = source.into_template_location(&clone_opts);
 
-        // 1. look for abbreviations like gh:, gl: etc.
-        let temp_location = abbreviated_git_url_to_full_remote(fav_name).map(|git_url| {
-            let git_user_in = GitUserInput::with_git_url_and_args(&git_url, args);
-            TemplateLocation::from(git_user_in)
-        });
-
-        // 2. check if template directory exist
-        let temp_location =
-            temp_location.or_else(|| local_path(fav_name).map(TemplateLocation::from));
-
-        // 3. check if the input is in form org/repo<> (map to github)
-        let temp_location = temp_location.or_else(|| {
-            abbreviated_github(fav_name).map(|git_url| {
-                let git_user_in = GitUserInput::with_git_url_and_args(&git_url, args);
-                TemplateLocation::from(git_user_in)
-            })
-        });
-
-        // 4. assume user wanted use --git
-        let temp_location = temp_location.unwrap_or_else(|| {
-            let git_user_in = GitUserInput::new(
-                &fav_name,
-                args.template_path.branch(),
-                args.template_path.tag(),
-                args.template_path.revision(),
-                ssh_identity,
-                args.gitconfig.clone(),
-                args.force_git_init,
-                args.skip_submodules,
-            );
-            TemplateLocation::from(git_user_in)
-        });
-
-        // Print information what happened to user
+        // Print information about what happened (preserve the existing warn!)
         let location_msg = match &temp_location {
             TemplateLocation::Git(git_user_input) => {
                 format!("git repository: {}", style(git_user_input.url()).bold())

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -958,9 +958,7 @@ fn test_flag_with_github_shorthand_clones_remote() {
         .assert()
         .failure()
         .stderr(
-            predicates::str::contains(
-                "Please check if the Git user / repository exists",
-            )
-            .from_utf8(),
+            predicates::str::contains("Please check if the Git user / repository exists")
+                .from_utf8(),
         );
 }

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -943,3 +943,24 @@ fn error_message_for_invalid_repo_or_user() {
                 .from_utf8(),
         );
 }
+
+#[test]
+fn test_flag_with_github_shorthand_clones_remote() {
+    // `cargo generate <owner/repo> --test` should attempt a github clone
+    // when no matching local directory exists. We assert the failure mode
+    // is "git user / repository not found" (clone attempted), NOT
+    // "No such file or directory" (treated as a local path).
+    let dir = tempdir().build();
+    binary()
+        .arg("not-a-real-org/definitely-does-not-exist")
+        .arg("--test")
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(
+            predicates::str::contains(
+                "Please check if the Git user / repository exists",
+            )
+            .from_utf8(),
+        );
+}

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -933,7 +933,7 @@ fn error_message_for_invalid_repo_or_user() {
     let dir = tempdir().build();
 
     binary()
-        .arg_git("sassman/cli-template-rs-xx")
+        .arg_git("my-org/my-repo")
         .arg_name("favorite-project")
         .current_dir(dir.path())
         .assert()

--- a/tests/integration/hooks_and_rhai.rs
+++ b/tests/integration/hooks_and_rhai.rs
@@ -193,7 +193,7 @@ fn it_fails_when_it_cant_execute_system_command() {
         .file(
             "system-script.rhai",
             indoc! {r#"
-                let output = system::command("dummy_command_that_doesn't_exist", ["dummy_arg"]);
+                let output = system::command("dummy_command_that_doesnt_exist", ["dummy_arg"]);
             "#},
         )
         .file(
@@ -215,15 +215,7 @@ fn it_fails_when_it_cant_execute_system_command() {
         .current_dir(dir.path())
         .assert()
         .failure()
-        .stderr(
-            // TODO: This error message is different on MacOS and Linux. We should unify it.
-            predicates::str::contains(if cfg!(target_os = "macos") {
-                "System command `dummy_command_that_doesn't_exist dummy_arg` failed to execute"
-            } else {
-                "Failed executing script: system-script.rhai"
-            })
-            .from_utf8(),
-        );
+        .stderr("dummy_command_that_doesnt_exist: command not found");
 }
 
 #[test]

--- a/tests/integration/hooks_and_rhai.rs
+++ b/tests/integration/hooks_and_rhai.rs
@@ -219,6 +219,8 @@ fn it_fails_when_it_cant_execute_system_command() {
             // TODO: This error message is different on MacOS and Linux. We should unify it.
             predicates::str::contains(if cfg!(target_os = "macos") {
                 "dummy_command_that_doesnt_exist: command not found"
+            } else if cfg!(target_os = "windows") {
+                "is not recognized as an internal or external command"
             } else {
                 "dummy_command_that_doesnt_exist: not found"
             })

--- a/tests/integration/hooks_and_rhai.rs
+++ b/tests/integration/hooks_and_rhai.rs
@@ -215,7 +215,15 @@ fn it_fails_when_it_cant_execute_system_command() {
         .current_dir(dir.path())
         .assert()
         .failure()
-        .stderr("dummy_command_that_doesnt_exist: command not found");
+        .stderr(
+            // TODO: This error message is different on MacOS and Linux. We should unify it.
+            predicates::str::contains(if cfg!(target_os = "macos") {
+                "dummy_command_that_doesnt_exist: command not found"
+            } else {
+                "dummy_command_that_doesnt_exist: not found"
+            })
+            .from_utf8(),
+        );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Removes process-wide `set_current_dir` from hook execution, rhai filter loading, and `--test` mode; production code already carries explicit base paths.
- Fixes the auth-git2 0.6 regression where tests and non-interactive runs hang on credential prompts: prompts are now explicitly disabled when stdin/stderr aren't terminals.
- Fixes a latent bug in `abbreviated_git_url_to_full_remote` where the org/repo fallthrough operated on the first three characters and could mangle `./path` into `https://github.com/./p.git`.
- Rewrites the relative-path tests to anchor on `example-templates/hooks` so they no longer mutate process cwd or race in parallel.
- Closes #1671.

## Note: classifier refactor included

A typed `TemplateSource` enum + `classify` resolver replaced the ad-hoc `Option<String>` ladders in `try_from_args_and_config` and the `--test` hijack in `main.rs`. Same end-user behaviour; the latent `./path` mangling and the `cargo generate <org/repo> --test` regression are both fixed by this layer rather than patched in place.

## Test plan

- [x] `cargo test --lib` — 171 passing
- [x] `cargo test --test integration` — 108 passing
- [x] `cargo clippy --all-targets` — clean
- [x] `basics::error_message_for_invalid_repo_or_user` no longer hangs on TTY-less runs
- [x] Manual: `cargo-generate --git <template> --test` runs `cargo test` against the expanded template
- [x] CI green on all platforms