### PR TITLE
chore(deps): bump rhai from 1.24.0 to 1.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9ef5dabe4c0b43d8f1187dc6beb67b53fe607fff7e30c5eb7f71b814b8c2c1"
+checksum = "5cdc552c1c198f0565e1deb9d85d380caedcc488e6ac3cb6f947c7ae77041e08"
 dependencies = [
  "ahash",
  "bitflags",
@@ -1871,9 +1871,9 @@ dependencies = [
 
 [[package]]
 name = "rhai_codegen"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4322a2a4e8cf30771dd9f27f7f37ca9ac8fe812dddd811096a98483080dabe6"
+checksum = "3cd3a7535e50bf36857e7be7bec276d334e8c2dfa469c2201226fd01638ea5ca"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ openssl = { version = "~0.10", optional = true }
 pastey = "~0.2"
 regex = "~1.12"
 remove_dir_all = "~1.0"
-rhai = "~1.24"
+rhai = "~1.25"
 sanitize-filename = "~0.6"
 semver = { version = "~1.0", features = ["serde"] }
 serde = { version = "~1.0", features = ["derive"] }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -38,7 +38,7 @@ fn evaluate_scripts(template_dir: &Path, scripts: &[String], engine: rhai::Engin
         let script: PathBuf = template_dir.join(script);
 
         let result = engine
-            .eval_file::<rhai::plugin::Dynamic>(script.clone())
+            .eval_file::<rhai::Dynamic>(script.clone())
             .map_err(|e| anyhow::anyhow!(e.to_string()))
             .with_context(|| {
                 format!(


### PR DESCRIPTION
## Summary
- Bumps the `rhai` dependency from `~1.24` to `~1.25`.
- Updates `src/hooks/mod.rs` to reference `rhai::Dynamic` directly. In 1.25 the `Dynamic` type is no longer re-exported under `rhai::plugin`, so the previous path fails to compile.

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — 171 lib + 106 integration tests pass, 0 failures
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo fmt --check` — clean

Co-authored-by: atlex00 <atlex00@gmail.com>
Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>