### PR TITLE
fix: hook files left in generated output (regression in v0.23.10)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,7 +561,10 @@ fn expand_template(
     // run post-hooks
     execute_hooks(&context, &config.get_post_hooks())?;
 
-    // remove all hook and filter files as they are never part of the template output
+    // remove all hook and filter files as they are never part of the template output.
+    // Hook files are configured as relative names, so anchor them to `template_dir`;
+    // `remove_dir_files` checks `Path::exists`, which would otherwise resolve them
+    // against the process CWD (the rhai filter files are already absolute).
     let rhai_filter_files = rhai_filter_files
         .lock()
         .unwrap()
@@ -571,7 +574,7 @@ fn expand_template(
     remove_dir_files(
         all_hook_files
             .into_iter()
-            .map(PathBuf::from)
+            .map(|hook_file| template_dir.join(hook_file))
             .chain(rhai_filter_files),
         false,
     );

--- a/tests/integration/hooks_and_rhai.rs
+++ b/tests/integration/hooks_and_rhai.rs
@@ -1,5 +1,47 @@
 use crate::helpers::prelude::*;
 
+// Regression test for #1671: hook scripts must be removed from the generated
+// output, and the removal must not touch a like-named file in the process CWD.
+#[test]
+fn it_removes_hook_files_from_output_without_touching_cwd() {
+    let template = tempdir()
+        .file(
+            "post-script.rhai",
+            indoc! {r#"
+            file::rename("RENAME-ME", "renamed");
+        "#},
+        )
+        .file("RENAME-ME", "content")
+        .file(
+            "cargo-generate.toml",
+            indoc! {r#"
+            [hooks]
+            post = ["post-script.rhai"]
+            "#},
+        )
+        .init_git()
+        .build();
+
+    // The directory we run from contains a decoy with the same name as the hook.
+    // Before the fix, the relative removal resolved against this CWD and deleted it.
+    let dir = tempdir().file("post-script.rhai", "decoy").build();
+
+    binary()
+        .arg_git(template.path())
+        .arg_name("script-project")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    // The hook ran...
+    assert!(dir.exists("script-project/renamed"));
+    // ...the hook script is gone from the output...
+    assert!(!dir.exists("script-project/post-script.rhai"));
+    // ...and the like-named decoy in the CWD was left untouched.
+    assert!(dir.exists("post-script.rhai"));
+    assert!(dir.read("post-script.rhai").contains("decoy"));
+}
+
 #[test]
 fn it_runs_all_hook_types() {
     let template = tempdir()


### PR DESCRIPTION
## Summary

Hook scripts declared under `[hooks]` are no longer removed from the generated
output — they get copied into the generated project. Worse, the cleanup can
**delete an unrelated file** that merely shares the hook's name in the directory
the command is run from.

This is a regression introduced in **v0.23.10** by #1672
("retire process-wide CWD mutation"). It affects both the CLI and the library
API on **v0.23.10** and **v0.23.11**; **v0.23.8** is clean.

## Root cause

`expand_template` removes hook/filter files after generation:

```rust
remove_dir_files(
    all_hook_files
        .into_iter()
        .map(PathBuf::from)          // configured hook names are *relative*
        .chain(rhai_filter_files),
    false,
);
```

`remove_dir_files` keeps only entries for which `Path::exists()` is true. For a
relative path that is resolved against the **process current working
directory**.

Before #1672, hook execution (`evaluate_scripts`) called
`env::set_current_dir(template_dir)` and left the process CWD pointing at the
template directory, so these relative paths happened to resolve correctly. #1672
deliberately retired that process-wide CWD mutation (a good change — it removed
a global side effect and a class of races), but the hook-file removal was still
implicitly depending on it. With the CWD no longer changed, the relative paths
now resolve against the caller's CWD:

- the hook files are not found in the output → **they leak into the generated project**;
- if the caller's CWD contains a same-named file, **that file is deleted instead**.

This is also why `cargo-generate.toml` is still stripped correctly: it goes
through `ignore_me::get_ignored`, which anchors names to the template `location`
(`location.join(file_name)`). Only the hook-file removal was left unanchored.

## Fix

Anchor the hook file names to `template_dir` before removal, mirroring
`get_ignored`:

```rust
remove_dir_files(
    all_hook_files
        .into_iter()
        .map(|hook_file| template_dir.join(hook_file))
        .chain(rhai_filter_files),
    false,
);
```

The rhai filter files are already absolute (`template_dir.join(&script_name)` in
`RhaiFilter::evaluate`), so they are unaffected.

## Reproduction

Minimal template:

```
mytemplate/
├── cargo-generate.toml   # [hooks]\n post = ["post-script.rhai"]
├── post-script.rhai      # // no-op
└── hello.txt             # hello
```

```
cargo generate --path ./mytemplate --name demo --vcs none --silent --force --destination ./out
```

- Expected: `out/demo/` contains only `hello.txt`.
- Before this PR (v0.23.10/v0.23.11): `out/demo/` also contains `post-script.rhai`.
- And if the CWD contains a `post-script.rhai`, that file is deleted.

| Version / entry point        | Result                     |
|------------------------------|----------------------------|
| 0.23.8 CLI                   | clean                      |
| 0.23.10 / 0.23.11 CLI        | leaks `post-script.rhai`   |
| 0.23.10 / 0.23.11 library    | leaks `post-script.rhai`   |
| this PR                      | clean                      |

