### PR TITLE
fix: use array defaults in silent mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -632,6 +632,10 @@ fn read_default_variable_value_from_template(slot: &TemplateSlots) -> Result<Str
             } => default.clone(),
             _ => return Err(()),
         },
+        VarInfo::Array { entry } => match &entry.default {
+            Some(default) => default.join(LIST_SEP),
+            None => return Err(()),
+        },
         _ => return Err(()),
     };
     let (key, value) = (&slot.var_name, &default_value);

--- a/tests/integration/template_config_file/placeholders.rs
+++ b/tests/integration/template_config_file/placeholders.rs
@@ -111,6 +111,39 @@ fn it_uses_array_defaults_in_silent_mode() {
 }
 
 #[test]
+fn it_fails_for_arrays_without_defaults_in_silent_mode() {
+    let template = tempdir()
+        .with_default_manifest()
+        .file(
+            "cargo-generate.toml",
+            indoc! {r#"
+                [template]
+                [placeholders.formats]
+                type = "array"
+                prompt = "Which MCU to target?"
+                choices = ["esp32", "esp32c2", "esp32c3", "esp32c6", "esp32s2", "esp32s3"]
+
+            "#},
+        )
+        .init_git()
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg("--silent")
+        .arg_git(template.path())
+        .arg_name("foobar-project")
+        .arg_branch("main")
+        .current_dir(dir.path())
+        .assert()
+        .failure()
+        .stderr(contains(
+            "variable `formats` is missing default value in config file running in silent mode",
+        ));
+}
+
+#[test]
 fn it_fails_on_invalid_multi_choices() {
     let template = tempdir()
         .with_default_manifest()

--- a/tests/integration/template_config_file/placeholders.rs
+++ b/tests/integration/template_config_file/placeholders.rs
@@ -71,6 +71,46 @@ fn it_substitutes_multi_selections() {
 }
 
 #[test]
+fn it_uses_array_defaults_in_silent_mode() {
+    let template = tempdir()
+        .with_default_manifest()
+        .file(
+            "cargo-generate.toml",
+            indoc! {r#"
+                [template]
+                [placeholders.formats]
+                type = "array"
+                prompt = "Which MCU to target?"
+                choices = ["esp32", "esp32c2", "esp32c3", "esp32c6", "esp32s2", "esp32s3"]
+                default = ["esp32", "esp32c3"]
+
+            "#},
+        )
+        .file(
+            "formats",
+            r#"[{%- for f in formats -%}"{{ f }}"{% unless forloop.last %}, {% endunless -%}{%- endfor -%}]"#,
+        )
+        .init_git()
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg("--silent")
+        .arg_git(template.path())
+        .arg_name("foobar-project")
+        .arg_branch("main")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert_eq!(
+        dir.read("foobar-project/formats"),
+        r#"["esp32", "esp32c3"]"#
+    );
+}
+
+#[test]
 fn it_fails_on_invalid_multi_choices() {
     let template = tempdir()
         .with_default_manifest()


### PR DESCRIPTION
## Summary

- Use configured array placeholder defaults when running in `--silent` mode.
- Add an integration test covering silent-mode generation without a provided array value.

## Why

Fixes #1621. Array defaults were parsed from `cargo-generate.toml`, but silent-mode default lookup only accepted bool and string placeholders before prompting/validation.

## Validation

- `cargo test it_uses_array_defaults_in_silent_mode --test integration -- --nocapture` — passed
- `cargo test template_config_file::placeholders --test integration` — passed
- `cargo fmt -- --check` — passed
- `cargo test` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo run -- generate --silent --path ./example-templates/arrays --name test-array-default --define description='this is a test'` — failed before the fix and passed after the fix
