### PR TITLE
fix: support array placeholders in conditionals

### DIFF
--- a/guide/src/templates/conditional.md
+++ b/guide/src/templates/conditional.md
@@ -4,6 +4,8 @@ Using `cargo-generate.toml`, values and some [`Rhai`] syntax, the template autho
 
 `include`, `exclude`, `ignore` and `placeholders` can all be used in sections that are only used based upon the value of one or more values, possibly input by the user using the interactive prompt (if the values in question are defined as placeholders in the non-conditional section).
 
+The condition inside `conditional.'...'` is evaluated as a [`Rhai`] expression. Placeholder arrays are exposed as Rhai arrays, so array helpers such as `.is_empty` and `.contains("serde")` can be used in these expressions.
+
 Using the following example, `cargo-generate` will ask for the `license`, and depending on the `--lib` | `--bin` flags it'll as for the `hypervisor` and `network_enabled` values. It will then continue to expand the template, ignoring the `src/main.rs` file (and thus excluding it from the output) in case `--lib` was specified.
 
 The example is broken up in order to explain each section.
@@ -79,3 +81,5 @@ ignore = [ "LICENSE-MIT.txt" ]
 This last conditional block is simply to ignore the unneeded license files, based upon the users choice for the `license` variable.
 
 > ⚠️ Note that `include` and `exclude` are still mutually exclusive even if they are in different, but included, conditional sections.
+
+[`Rhai`]: https://rhai.rs/book/

--- a/src/git/clone_tool.rs
+++ b/src/git/clone_tool.rs
@@ -67,10 +67,7 @@ impl<'cb> RepoCloneBuilder<'cb> {
             self.gitconfig = Some(Config::open(gitconfig.as_path())?);
 
             if let Some(url) = gitconfig::resolve_instead_url(&self.url, gitconfig)? {
-                debug!(
-                    "{} gitconfig 'insteadOf' lead to this url: {}",
-                    &WRENCH, url
-                );
+                debug!("{} gitconfig 'insteadOf' lead to this url: {}", WRENCH, url);
                 self.url = url;
             }
         }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -5,7 +5,6 @@ use heck::{
     ToKebabCase, ToLowerCamelCase, ToPascalCase, ToShoutyKebabCase, ToShoutySnakeCase, ToSnakeCase,
     ToTitleCase, ToUpperCamelCase,
 };
-use liquid::ValueView;
 use log::debug;
 use rhai::module_resolvers::FileModuleResolver;
 use rhai::EvalAltResult;
@@ -103,16 +102,9 @@ pub fn evaluate_script<T: Clone + 'static>(
                 .map_err(|_| PoisonError::new_eval_alt_result())?
                 .borrow()
                 .get(name)
+                .cloned()
                 .map_or(Ok(None), |value| {
-                    Ok(value.as_view().as_scalar().map(|scalar| {
-                        scalar.to_bool().map_or_else(
-                            || {
-                                let v = scalar.to_kstr();
-                                v.as_str().into()
-                            },
-                            |v| v.into(),
-                        )
-                    }))
+                    variable_mod::liquid_to_rhai_value(value).map(Some)
                 })
         }
     });

--- a/src/hooks/variable_mod.rs
+++ b/src/hooks/variable_mod.rs
@@ -286,7 +286,7 @@ fn rhai_to_liquid_value(val: Dynamic) -> HookResult<Value> {
         })
 }
 
-fn liquid_to_rhai_value(val: Value) -> HookResult<Dynamic> {
+pub(super) fn liquid_to_rhai_value(val: Value) -> HookResult<Dynamic> {
     match val {
         Value::Scalar(scalar) => {
             // Try to convert to bool first, then to string

--- a/src/ignore_me.rs
+++ b/src/ignore_me.rs
@@ -82,7 +82,7 @@ pub fn remove_dir_files(files: impl IntoIterator<Item = impl Into<PathBuf>>, ver
         .map(|i| i.into() as PathBuf)
         .filter(|file| file.exists())
     {
-        let ignore_message = format!("Ignoring: {}", &item.display());
+        let ignore_message = format!("Ignoring: {}", item.display());
         if item.is_dir() {
             remove_dir_all(&item).unwrap();
             if verbose {
@@ -96,7 +96,7 @@ pub fn remove_dir_files(files: impl IntoIterator<Item = impl Into<PathBuf>>, ver
         } else {
             warn!(
                 "The given paths are neither files nor directories! {}",
-                &item.display()
+                item.display()
             );
         }
     }

--- a/tests/integration/conditionals.rs
+++ b/tests/integration/conditionals.rs
@@ -234,3 +234,71 @@ fn it_supports_conditions_with_creepy_shit_inside() {
         .read("foobar-project/included")
         .contains("styling3 = Tailwind"));
 }
+
+#[test]
+fn it_supports_array_contains_in_conditionals() {
+    let template = tempdir()
+        .file(
+            "cargo-generate.toml",
+            indoc! {r#"
+                [placeholders.features]
+                type = "array"
+                prompt = "Which features should be enabled?"
+                choices = ["serde", "async"]
+                default = ["serde"]
+
+                [conditional.'features.contains("serde")']
+                ignore = ["without-serde"]
+            "#},
+        )
+        .file("without-serde", "no serde")
+        .init_git()
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg("--silent")
+        .arg_git(template.path())
+        .arg_name("foobar-project")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(dir.exists("foobar-project/without-serde").not());
+}
+
+#[test]
+fn it_supports_array_is_empty_in_conditionals() {
+    let template = tempdir()
+        .file(
+            "cargo-generate.toml",
+            indoc! {r#"
+                [placeholders.targets]
+                type = "array"
+                prompt = "Which targets should be enabled?"
+                choices = ["linux", "windows"]
+                default = []
+
+                [conditional.'targets.is_empty']
+                ignore = ["with-targets"]
+            "#},
+        )
+        .file("with-targets", "targets selected")
+        .init_git()
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg("--silent")
+        .arg_git(template.path())
+        .arg_name("foobar-project")
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(dir.exists("foobar-project/with-targets").not());
+}


### PR DESCRIPTION
## Summary

- Expose placeholder arrays as Rhai arrays when evaluating `conditional.'...'` blocks.
- Add regression coverage for `.contains(...)` and `.is_empty` array conditionals.
- Document that conditional expressions use Rhai syntax.

## Why

Fixes #1429. Array placeholders were already present in the template values, but the conditional evaluator only returned scalar values to Rhai, so array conditions were treated as missing/false.

## Validation

- `cargo test --test integration array_ -- --nocapture` — failed before the fix and passed after
- `cargo test --test integration conditionals:: -- --nocapture` — passed
- `cargo test --lib hooks::variable_mod -- --nocapture` — passed
- `cargo fmt -- --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo test` — passed
- `git diff --check` — passed