### PR TITLE
fix: fetch full history for revision checkouts

### DIFF
--- a/src/git/clone_tool.rs
+++ b/src/git/clone_tool.rs
@@ -12,6 +12,14 @@ fn interactive_auth_allowed() -> bool {
     std::io::stdin().is_terminal() && std::io::stderr().is_terminal()
 }
 
+fn is_http_repo_url(url: &str) -> bool {
+    url.starts_with("http://") || url.starts_with("https://")
+}
+
+fn should_limit_fetch_depth(url: &str, requires_full_history: bool) -> bool {
+    is_http_repo_url(url) && !requires_full_history
+}
+
 use crate::emoji::WRENCH;
 
 use super::gitconfig;
@@ -25,6 +33,7 @@ pub struct RepoCloneBuilder<'cb> {
     skip_submodules: bool,
     destination_path: Option<PathBuf>,
     tag_or_revision: Option<String>,
+    requires_full_history: bool,
     gitconfig: Option<Config>,
     interactive: bool,
 }
@@ -48,6 +57,7 @@ impl<'cb> RepoCloneBuilder<'cb> {
             skip_submodules: false,
             destination_path: None,
             tag_or_revision: None,
+            requires_full_history: false,
             gitconfig: None,
             interactive,
         }
@@ -117,6 +127,7 @@ impl<'cb> RepoCloneBuilder<'cb> {
     pub fn with_tag(mut self, tag: Option<&str>) -> Self {
         if let Some(tag) = tag {
             self.tag_or_revision = Some(tag.to_owned());
+            self.requires_full_history = false;
         }
 
         self
@@ -127,6 +138,7 @@ impl<'cb> RepoCloneBuilder<'cb> {
     pub fn with_revision(mut self, revision: Option<&str>) -> Self {
         if let Some(revision) = revision {
             self.tag_or_revision = Some(revision.to_owned());
+            self.requires_full_history = true;
         }
 
         self
@@ -168,9 +180,9 @@ impl GitCloneCmd<'_> {
         let url = self.builder.url.clone();
 
         let is_ssh_repo = url.starts_with("ssh}://") || url.starts_with("git@");
-        let is_http_repo = url.starts_with("http://") || url.starts_with("https://");
+        let is_http_repo = is_http_repo_url(&url);
 
-        if is_http_repo {
+        if should_limit_fetch_depth(&url, self.builder.requires_full_history) {
             let mut proxy_options = ProxyOptions::new();
             proxy_options.auto();
 
@@ -230,5 +242,56 @@ impl GitCloneCmd<'_> {
         }
 
         Ok(repo)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{should_limit_fetch_depth, RepoCloneBuilder};
+
+    #[test]
+    fn http_clones_are_shallow_by_default() {
+        assert!(should_limit_fetch_depth(
+            "https://github.com/example/template",
+            false
+        ));
+    }
+
+    #[test]
+    fn revision_clones_skip_shallow_http_fetch() {
+        assert!(!should_limit_fetch_depth(
+            "https://github.com/example/template",
+            true
+        ));
+    }
+
+    #[test]
+    fn non_http_clones_do_not_set_fetch_depth() {
+        assert!(!should_limit_fetch_depth("git@example.com:repo.git", false));
+    }
+
+    #[test]
+    fn revision_clones_require_full_history() {
+        let builder =
+            RepoCloneBuilder::new("https://github.com/example/template").with_revision(Some("abc"));
+
+        assert!(builder.requires_full_history);
+    }
+
+    #[test]
+    fn tag_clones_can_stay_shallow() {
+        let builder =
+            RepoCloneBuilder::new("https://github.com/example/template").with_tag(Some("v1.0.0"));
+
+        assert!(!builder.requires_full_history);
+    }
+
+    #[test]
+    fn tag_overrides_previous_revision_history_requirement() {
+        let builder = RepoCloneBuilder::new("https://github.com/example/template")
+            .with_revision(Some("abc"))
+            .with_tag(Some("v1.0.0"));
+
+        assert!(!builder.requires_full_history);
     }
 }

--- a/src/git/clone_tool.rs
+++ b/src/git/clone_tool.rs
@@ -77,10 +77,7 @@ impl<'cb> RepoCloneBuilder<'cb> {
             self.gitconfig = Some(Config::open(gitconfig.as_path())?);
 
             if let Some(url) = gitconfig::resolve_instead_url(&self.url, gitconfig)? {
-                debug!(
-                    "{} gitconfig 'insteadOf' lead to this url: {}",
-                    &WRENCH, url
-                );
+                debug!("{} gitconfig 'insteadOf' lead to this url: {}", WRENCH, url);
                 self.url = url;
             }
         }

--- a/src/ignore_me.rs
+++ b/src/ignore_me.rs
@@ -82,7 +82,7 @@ pub fn remove_dir_files(files: impl IntoIterator<Item = impl Into<PathBuf>>, ver
         .map(|i| i.into() as PathBuf)
         .filter(|file| file.exists())
     {
-        let ignore_message = format!("Ignoring: {}", &item.display());
+        let ignore_message = format!("Ignoring: {}", item.display());
         if item.is_dir() {
             remove_dir_all(&item).unwrap();
             if verbose {
@@ -96,7 +96,7 @@ pub fn remove_dir_files(files: impl IntoIterator<Item = impl Into<PathBuf>>, ver
         } else {
             warn!(
                 "The given paths are neither files nor directories! {}",
-                &item.display()
+                item.display()
             );
         }
     }


### PR DESCRIPTION
## Summary

- Skip the depth-1 HTTP fetch when cloning a template for a raw `--revision` checkout.
- Keep ordinary HTTP clones shallow.
- Add unit coverage for the fetch-depth decision.

## Why

Fixes #1434. A depth-1 HTTP clone may not contain the requested commit SHA, so `revparse` can fail with `revspec ... not found` even though the revision exists in the repository.

## Validation

- `cargo run -- generate --git https://github.com/rust-embedded/cortex-m-quickstart --rev ac02415275d0190a1a7aa730ec2b0bdf7c3ef88f --name my-app --destination /tmp/cg-rev-repro --silent --skip-submodules` — failed before the fix and passed after
- `cargo test --lib git::clone_tool -- --nocapture` — passed
- `cargo test --test integration git::it_allows_a_git_revision_to_be_specified -- --nocapture` — passed
- `cargo fmt -- --check` — passed
- `cargo test` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `git diff --check` — passed