### PR TITLE
fix: use default sub-template in silent mode

### DIFF
--- a/src/git/clone_tool.rs
+++ b/src/git/clone_tool.rs
@@ -67,10 +67,7 @@ impl<'cb> RepoCloneBuilder<'cb> {
             self.gitconfig = Some(Config::open(gitconfig.as_path())?);
 
             if let Some(url) = gitconfig::resolve_instead_url(&self.url, gitconfig)? {
-                debug!(
-                    "{} gitconfig 'insteadOf' lead to this url: {}",
-                    &WRENCH, url
-                );
+                debug!("{} gitconfig 'insteadOf' lead to this url: {}", WRENCH, url);
                 self.url = url;
             }
         }

--- a/src/ignore_me.rs
+++ b/src/ignore_me.rs
@@ -101,3 +101,24 @@ pub fn remove_dir_files(files: impl IntoIterator<Item = impl Into<PathBuf>>, ver
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::remove_dir_files;
+    use std::fs;
+
+    #[test]
+    fn remove_dir_files_removes_existing_files_and_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("generated.txt");
+        let dir = temp.path().join("generated-dir");
+        fs::write(&file, "generated").unwrap();
+        fs::create_dir(&dir).unwrap();
+        fs::write(dir.join("nested.txt"), "nested").unwrap();
+
+        remove_dir_files([file.as_path(), dir.as_path()], true);
+
+        assert!(!file.exists());
+        assert!(!dir.exists());
+    }
+}

--- a/src/ignore_me.rs
+++ b/src/ignore_me.rs
@@ -82,7 +82,7 @@ pub fn remove_dir_files(files: impl IntoIterator<Item = impl Into<PathBuf>>, ver
         .map(|i| i.into() as PathBuf)
         .filter(|file| file.exists())
     {
-        let ignore_message = format!("Ignoring: {}", &item.display());
+        let ignore_message = format!("Ignoring: {}", item.display());
         if item.is_dir() {
             remove_dir_all(&item).unwrap();
             if verbose {
@@ -96,7 +96,7 @@ pub fn remove_dir_files(files: impl IntoIterator<Item = impl Into<PathBuf>>, ver
         } else {
             warn!(
                 "The given paths are neither files nor directories! {}",
-                &item.display()
+                item.display()
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,11 @@ fn prepare_local_template(
     source_template: &UserParsedInput,
 ) -> Result<(TempDir, PathBuf, Option<String>), anyhow::Error> {
     let (temp_dir, branch) = get_source_template_into_temp(source_template.location())?;
-    let template_folder = resolve_template_dir(&temp_dir, source_template.subfolder())?;
+    let template_folder = resolve_template_dir(
+        &temp_dir,
+        source_template.subfolder(),
+        source_template.silent(),
+    )?;
 
     Ok((temp_dir, template_folder, branch))
 }
@@ -297,10 +301,29 @@ fn strip_liquid_suffixes(dir: impl AsRef<Path>) -> Result<()> {
 }
 
 /// resolve the template location for the actual template to expand
-fn resolve_template_dir(template_base_dir: &TempDir, subfolder: Option<&str>) -> Result<PathBuf> {
+fn resolve_template_dir(
+    template_base_dir: &TempDir,
+    subfolder: Option<&str>,
+    silent: bool,
+) -> Result<PathBuf> {
     let template_dir = resolve_template_dir_subfolder(template_base_dir.path(), subfolder)?;
     auto_locate_template_dir(template_dir, &mut |slots| {
-        prompt_and_check_variable(slots, None)
+        if silent {
+            read_default_variable_value_from_template(slots).map_err(|()| {
+                anyhow!(
+                    "{} {}",
+                    emoji::ERROR,
+                    style(format!(
+                        "Option `--silent` provided, but `{}` has no default value.",
+                        slots.var_name
+                    ))
+                    .bold()
+                    .red()
+                )
+            })
+        } else {
+            prompt_and_check_variable(slots, None)
+        }
     })
 }
 
@@ -787,7 +810,7 @@ mod tests {
     use crate::{
         auto_locate_template_dir, extract_toml_string,
         project_variables::{StringKind, VarInfo},
-        tmp_dir,
+        resolve_template_dir, tmp_dir,
     };
     use anyhow::anyhow;
     use std::{
@@ -861,6 +884,27 @@ mod tests {
         })?
         .canonicalize()?;
         let expected = tmp.path().join("sub2").canonicalize()?;
+
+        assert_eq!(expected, actual);
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_template_dir_uses_default_subtemplate_in_silent_mode() -> anyhow::Result<()> {
+        let tmp = tmp_dir().unwrap();
+        create_file(
+            &tmp,
+            "cargo-generate.toml",
+            indoc::indoc! {r#"
+                [template]
+                sub_templates = ["sub1", "sub2"]
+            "#},
+        )?;
+        create_file(&tmp, "sub1/Cargo.toml", "")?;
+        create_file(&tmp, "sub2/Cargo.toml", "")?;
+
+        let actual = resolve_template_dir(&tmp, None, true)?.canonicalize()?;
+        let expected = tmp.path().join("sub1").canonicalize()?;
 
         assert_eq!(expected, actual);
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,22 +308,32 @@ fn resolve_template_dir(
 ) -> Result<PathBuf> {
     let template_dir = resolve_template_dir_subfolder(template_base_dir.path(), subfolder)?;
     auto_locate_template_dir(template_dir, &mut |slots| {
-        if silent {
-            read_default_variable_value_from_template(slots).map_err(|()| {
-                anyhow!(
-                    "{} {}",
-                    emoji::ERROR,
-                    style(format!(
-                        "Option `--silent` provided, but `{}` has no default value.",
-                        slots.var_name
-                    ))
-                    .bold()
-                    .red()
-                )
-            })
-        } else {
+        select_sub_template(slots, silent, |slots| {
             prompt_and_check_variable(slots, None)
-        }
+        })
+    })
+}
+
+fn select_sub_template(
+    slots: &TemplateSlots,
+    silent: bool,
+    prompt: impl FnOnce(&TemplateSlots) -> Result<String>,
+) -> Result<String> {
+    if !silent {
+        return prompt(slots);
+    }
+
+    read_default_variable_value_from_template(slots).map_err(|()| {
+        anyhow!(
+            "{} {}",
+            emoji::ERROR,
+            style(format!(
+                "Option `--silent` provided, but `{}` has no default value.",
+                slots.var_name
+            ))
+            .bold()
+            .red()
+        )
     })
 }
 
@@ -809,8 +819,8 @@ fn check_cargo_generate_version(template_config: &Config) -> Result<(), anyhow::
 mod tests {
     use crate::{
         auto_locate_template_dir, extract_toml_string,
-        project_variables::{StringKind, VarInfo},
-        resolve_template_dir, tmp_dir,
+        project_variables::{StringEntry, StringKind, TemplateSlots, VarInfo},
+        resolve_template_dir, select_sub_template, tmp_dir,
     };
     use anyhow::anyhow;
     use std::{
@@ -908,6 +918,56 @@ mod tests {
 
         assert_eq!(expected, actual);
         Ok(())
+    }
+
+    #[test]
+    fn select_sub_template_uses_configured_default_in_silent_mode() -> anyhow::Result<()> {
+        let slot = sub_template_slot(Some("sub1"));
+
+        let actual = select_sub_template(&slot, true, |_| {
+            unreachable!("silent mode should not prompt")
+        })?;
+
+        assert_eq!("sub1", actual);
+        Ok(())
+    }
+
+    #[test]
+    fn select_sub_template_errors_without_default_in_silent_mode() {
+        let slot = sub_template_slot(None);
+
+        let err = select_sub_template(&slot, true, |_| Ok("sub2".into())).unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("Option `--silent` provided"));
+        assert!(message.contains("`Template` has no default value"));
+    }
+
+    #[test]
+    fn select_sub_template_prompts_outside_silent_mode() -> anyhow::Result<()> {
+        let slot = sub_template_slot(Some("sub1"));
+
+        let actual = select_sub_template(&slot, false, |slots| {
+            assert_eq!("Template", slots.var_name);
+            Ok("sub2".into())
+        })?;
+
+        assert_eq!("sub2", actual);
+        Ok(())
+    }
+
+    fn sub_template_slot(default: Option<&str>) -> TemplateSlots {
+        TemplateSlots {
+            prompt: "Which sub-template should be expanded?".into(),
+            var_name: "Template".into(),
+            var_info: VarInfo::String {
+                entry: Box::new(StringEntry {
+                    default: default.map(str::to_owned),
+                    kind: StringKind::Choices(vec!["sub1".into(), "sub2".into()]),
+                    regex: None,
+                }),
+            },
+        }
     }
 
     #[test]

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -46,6 +46,52 @@ fn it_can_use_a_specified_path() {
 }
 
 #[test]
+fn it_uses_the_default_subtemplate_in_silent_mode() {
+    let template = tempdir()
+        .file(
+            "cargo-generate.toml",
+            indoc! {r#"
+                [template]
+                sub_templates = ["sub1", "sub2"]
+            "#},
+        )
+        .file(
+            "sub1/Cargo.toml",
+            indoc! {r#"
+                [package]
+                name = "{{project-name}}"
+                description = "first subtemplate"
+                version = "0.1.0"
+            "#},
+        )
+        .file("sub1/source.txt", "sub1")
+        .file(
+            "sub2/Cargo.toml",
+            indoc! {r#"
+                [package]
+                name = "{{project-name}}"
+                description = "second subtemplate"
+                version = "0.1.0"
+            "#},
+        )
+        .file("sub2/source.txt", "sub2")
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg("--silent")
+        .arg_name("foobar-project")
+        .arg_path(template.path())
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert_eq!("sub1", dir.read("foobar-project/source.txt"));
+}
+
+#[test]
 fn it_substitutes_projectname_in_cargo_toml() {
     let template = tempdir().init_default_template().build();
 


### PR DESCRIPTION
## Summary

- use the configured default sub-template instead of prompting in `--silent` mode
- add unit and CLI regression coverage for the default sub-template path
- update existing formatting-only Clippy warnings from Rust 1.97

## Why

Fixes #1181. `sub_templates` already mark the first entry as the default, so silent mode should use it rather than waiting for an interactive selection.

## Validation

- `cargo test --lib select_sub_template -- --nocapture` — passed
- `cargo test --lib remove_dir_files_removes_existing_files_and_directories -- --nocapture` — passed
- `cargo test --lib resolve_template_dir_uses_default_subtemplate_in_silent_mode -- --nocapture` — passed
- `cargo test --test integration it_uses_the_default_subtemplate_in_silent_mode -- --nocapture` — passed
- `cargo test --lib auto_locate_template -- --nocapture` — passed
- `cargo test` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — passed
- `cargo fmt -- --check` — passed
- `git diff --check` — passed