### PR TITLE
test: accept GNU mkdir errors on macOS

### DIFF
--- a/tests/integration/hooks_and_rhai.rs
+++ b/tests/integration/hooks_and_rhai.rs
@@ -1,5 +1,7 @@
 use crate::helpers::prelude::*;
 
+const UNIX_MKDIR_ERROR_PATTERN: &str = r"System command `mkdir invalid_/.dir_name` failed to execute: mkdir: .*No such file or directory";
+
 // Regression test for #1671: hook scripts must be removed from the generated
 // output, and the removal must not touch a like-named file in the process CWD.
 #[test]
@@ -213,20 +215,27 @@ fn it_fails_when_a_system_command_returns_non_zero_exit_code() {
         .assert()
         .failure()
         .stderr(
-            if cfg!(target_os = "linux") {
-                predicates::str::is_match(
-                    r"System command `mkdir invalid_/.dir_name` failed to execute: mkdir: cannot create directory [‘']invalid_/\.dir_name[’']: No such file or directory"
-                ).unwrap().from_utf8()
-            } else if cfg!(target_os = "macos") {
-                predicates::str::is_match(
-                    r"System command `mkdir invalid_/.dir_name` failed to execute: mkdir: invalid_: No such file or directory"
-                ).unwrap().from_utf8()
-            } else { // Windows
+            if cfg!(unix) {
+                predicates::str::is_match(UNIX_MKDIR_ERROR_PATTERN)
+                    .unwrap()
+                    .from_utf8()
+            } else {
                 predicates::str::is_match(
                     r"System command `mkdir invalid_/.dir_name` failed to execute: The syntax of the command is incorrect\."
                 ).unwrap().from_utf8()
             }
         );
+}
+
+#[test]
+fn unix_mkdir_error_pattern_accepts_gnu_and_bsd_output() {
+    let predicate = predicates::str::is_match(UNIX_MKDIR_ERROR_PATTERN).unwrap();
+    assert!(predicate.eval(
+        "System command `mkdir invalid_/.dir_name` failed to execute: mkdir: cannot create directory 'invalid_/.dir_name': No such file or directory"
+    ));
+    assert!(predicate.eval(
+        "System command `mkdir invalid_/.dir_name` failed to execute: mkdir: invalid_: No such file or directory"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- match the stable command prefix and `No such file or directory` suffix for Unix `mkdir` failures
- cover both GNU and BSD error forms directly

## Why

The integration test selects an expected message from the host OS, but macOS can run GNU `mkdir` under Nix. The command behavior is correct; only the platform-name assumption makes the suite fail.

Closes #1541

## Validation

- `cargo test --locked` — passed (182 unit and 113 integration tests)
- `cargo clippy --all-targets --locked -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed