### PR TITLE
docs: overhaul install + git-over-ssh chapters for gix

### DIFF
--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -1,40 +1,14 @@
 # Installation
 
-## Using `cargo-generate` with vendored `libgit2` and system's OpenSSL
-By default, cargo-generate uses vendored sources for `libgit2` and OpenSSL that is installed on your system.
+## From crates.io
 
 ```sh
 cargo install cargo-generate --locked
 ```
 
-This requires the following dependencies on your system:
-- `libssl-dev` (this could also be named openssl)
-
-## Using `cargo-generate` with vendored OpenSSL
-However, you can also opt in to use a vendored OpenSSL version.
-So that you don't have to have OpenSSL installed and built it on the spot.
-
-this would require the following dependencies on your system, as documented by the [`openssl` crate]:
-- A C compiler (`gcc`, for example)
-- `perl` and `perl-core`
-- `make`
-
-```sh
-cargo install cargo-generate --features vendored-openssl
-```
-
-## Using `cargo-generate` with system's `libgit2` and system's OpenSSL
-You can opt-out of vendored libraries and use `libgit2` and OpenSSL from your system
-by building cargo-generate without the default dependencies.
-
-```sh
-cargo install cargo-generate --no-default-features
-```
-
-This will require the following dependencies on your system:
-- `pkg-config`
-- `libgit2`
-- `libssl-dev` (this could also be named openssl)
+No system libraries are required. Since the migration to [`gix`], cargo-generate
+uses pure-Rust git via [`gix`] and TLS via [`rustls`], so a plain Rust toolchain
+is all you need — no `pkg-config`, `libgit2`, `libssl-dev`, `perl`, or C compiler.
 
 ## Using `pacman` (Arch Linux)
 
@@ -47,8 +21,9 @@ pacman -S cargo-generate
 ## Manual Installation
 
 1. Download the binary tarball for your platform from our [releases page].
-2. Unpack the tarball and place the binary `cargo-generate` in `~/.cargo/bin/`
+2. Unpack the tarball and place the binary `cargo-generate` in `~/.cargo/bin/`.
 
-[`openssl` crate]: https://docs.rs/openssl
+[`gix`]: https://crates.io/crates/gix
+[`rustls`]: https://crates.io/crates/rustls
 [extra repository]: https://archlinux.org/packages/extra/x86_64/cargo-generate/
 [releases page]: https://github.com/cargo-generate/cargo-generate/releases

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -6,9 +6,9 @@
 cargo install cargo-generate --locked
 ```
 
-No system libraries are required. Since the migration to [`gix`], cargo-generate
-uses pure-Rust git via [`gix`] and TLS via [`rustls`], so a plain Rust toolchain
-is all you need — no `pkg-config`, `libgit2`, `libssl-dev`, `perl`, or C compiler.
+No system libraries are required. New in version [1.0.0] is the pure-Rust git
+stack via [`gix`] and TLS via [`rustls`], so a plain Rust toolchain is all you
+need — no `pkg-config`, `libgit2`, `libssl-dev`, `perl`, or C compiler.
 
 ## Using `pacman` (Arch Linux)
 
@@ -23,6 +23,7 @@ pacman -S cargo-generate
 1. Download the binary tarball for your platform from our [releases page].
 2. Unpack the tarball and place the binary `cargo-generate` in `~/.cargo/bin/`.
 
+[1.0.0]: https://github.com/cargo-generate/cargo-generate/releases/tag/v1.0.0
 [`gix`]: https://crates.io/crates/gix
 [`rustls`]: https://crates.io/crates/rustls
 [extra repository]: https://archlinux.org/packages/extra/x86_64/cargo-generate/

--- a/guide/src/usage/git-over-ssh.md
+++ b/guide/src/usage/git-over-ssh.md
@@ -1,9 +1,7 @@
 # Git over SSH
 
-New in version [0.7.0] is the support for both public and private and ssh git remote urls.
-New in version [0.22.0] is the support for `ssh-agent` on Windows and interactively asking for passphrase for password protected keys on *Nix and macOS.
-
-There are 2 different git over ssh urls, one with the `git@` prefix and one with the `ssh://` prefix. Both are supported. Please note that the `ssh://` prefix url uses a path where the `git@` prefix uses a colon at the user/github-org level. For example:
+Both SSH URL forms are supported. Note that the `ssh://` form uses a path
+separator, while the `git@` shorthand uses a colon between host and org:
 
 ```raw
 git@github.com:rustwasm/wasm-pack-template.git
@@ -13,62 +11,71 @@ git@github.com:rustwasm/wasm-pack-template.git
 ssh://git@github.com/rustwasm/wasm-pack-template.git
 ```
 
-Both those urls can also be used in the `.gitconfig` insteadOf configuration, see more in the section below.
+Either one can also be used as the right-hand side of `.gitconfig`
+`insteadOf` — see the next chapter.
 
 ```sh
 cargo generate --git git@github.com:rustwasm/wasm-pack-template.git --name mywasm
 ```
 
-## Authentication using `ssh-agent`
+## How authentication works
 
-New in version [0.15.1] is the `ssh-agent` usage for password protected keys. It's also the default mechanism on Windows.
+Since the migration to [`gix`], cargo-generate delegates all SSH concerns to
+the system `ssh` binary. In practice that means:
+
+* `ssh-agent` is picked up automatically wherever the OS exposes it.
+* `~/.ssh/config` is honored, including per-host `IdentityFile`,
+  `IdentitiesOnly`, `ProxyJump`, and friends.
+* Default identity discovery is whatever your `ssh` uses — typically
+  `~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, etc.
+* Passphrase prompts come from `ssh` (or the agent) directly, so they look
+  and behave exactly like a plain `git clone`.
+
+No cargo-generate–specific configuration is needed for the common case: if
+`git clone <ssh-url>` works in your shell, so does
+`cargo generate --git <ssh-url>`.
 
 ### On Windows
 
-`ssh-agent` is the default and also **the only** possibility to get git+ssh working.
-Please follow [this guide](https://github.com/cargo-generate/cargo-generate/discussions/653) to get `ssh-agent` configured on windows.
+`ssh-agent` ships as an optional service with modern Windows. Follow
+[this guide](https://github.com/cargo-generate/cargo-generate/discussions/653)
+for one-time setup; once it's running, cargo-generate uses it transparently.
 
-### On *Nix and macOS
+## Custom SSH identity file (private key)
 
-If you omit the identity file (read the next paragraph) **OR** a provided identity file does not exist, then the default is to use `ssh-agent`.
+If you need a specific key for a single invocation, pass it with
+`-i` / `--identity`:
 
-## Ssh identity file defaults
-
-Since version [0.22.0] the default mechanism on unix/macOS is to use the function [`add_default_ssh_keys`](https://github.com/de-vri-es/auth-git2-rs/blob/fd6502e20b9e82063b950ac9e32f6454341e71f2/src/lib.rs#L344) that adds a couple of default keys to look up first.
-
-```
-// the list used..
-let candidates = [
-			"id_rsa",
-			"id_ecdsa,",
-			"id_ecdsa_sk",
-			"id_ed25519",
-			"id_ed25519_sk",
-			"id_dsa",
-		];
+```sh
+cargo generate -i ~/.ssh/id_rsa_other --git git@github.com:org/template.git
 ```
 
-## Custom ssh identity file (private key)
+Under the hood this becomes an in-memory `core.sshCommand = ssh -i <path>`
+override — equivalent to running git with `GIT_SSH_COMMAND=ssh -i <path>`.
+Passphrase prompts (if any) come from `ssh` directly.
 
-However, if you use a different file, you can pass a custom ssh identity with via `-i | --identity` like `-i ~/.ssh/id_rsa_other` as argument.
+For a persistent choice, `~/.ssh/config` is usually the cleanest option:
 
-If the file is passphrase protected cargo-generate will ask for the passphrase interactively.
+```
+Host github.com
+    IdentityFile ~/.ssh/id_rsa_other
+    IdentitiesOnly yes
+```
 
-If you permanently want to use a custom identity file, you can configure it in the cargo-generate config file like this:
+Alternatively, configure it in the cargo-generate config file:
 
 ```toml
 # an extract of ~/.cargo/cargo-generate.toml
 [defaults]
-# note that `~/` and `$HOME/` are going to be expanded to the full path seamlessly
+# note that `~/` and `$HOME/` are expanded to the full path seamlessly
 ssh_identity = "~/.ssh/id_rsa_other"
-# that is equivalent to
+# equivalent to
 ssh_identity = "$HOME/.ssh/id_rsa_other"
-# that is equivalent to
+# equivalent to
 ssh_identity = "/home/john/.ssh/id_rsa_other"
 ```
 
-> ⚠️ NOTE: that the cli argument `-i` always overrules the `ssh_identity` from the config file.
+> ⚠️ NOTE: the CLI argument `-i` always overrules `ssh_identity` from the
+> config file.
 
-[0.7.0]: https://github.com/cargo-generate/cargo-generate/releases/tag/v0.7.0
-[0.15.1]: https://github.com/cargo-generate/cargo-generate/releases/tag/v0.15.1
-[0.22.0]: https://github.com/cargo-generate/cargo-generate/releases/tag/v0.22.0
+[`gix`]: https://github.com/GitoxideLabs/gitoxide

--- a/guide/src/usage/git-over-ssh.md
+++ b/guide/src/usage/git-over-ssh.md
@@ -20,8 +20,8 @@ cargo generate --git git@github.com:rustwasm/wasm-pack-template.git --name mywas
 
 ## How authentication works
 
-Since the migration to [`gix`], cargo-generate delegates all SSH concerns to
-the system `ssh` binary. In practice that means:
+New in version [1.0.0] is the full delegation of SSH to the system `ssh`
+binary (via [`gix`]). In practice that means:
 
 * `ssh-agent` is picked up automatically wherever the OS exposes it.
 * `~/.ssh/config` is honored, including per-host `IdentityFile`,
@@ -78,4 +78,5 @@ ssh_identity = "/home/john/.ssh/id_rsa_other"
 > ⚠️ NOTE: the CLI argument `-i` always overrules `ssh_identity` from the
 > config file.
 
+[1.0.0]: https://github.com/cargo-generate/cargo-generate/releases/tag/v1.0.0
 [`gix`]: https://github.com/GitoxideLabs/gitoxide


### PR DESCRIPTION
Third stacked PR on top of #1749 — merge after #1460 and #1749 land.

Iterating on the docs in isolation so the code-carrying PRs stay small and reviewable.

## What

- **`installation.md`** — drops the three vendored-libgit2 / vendored-openssl variants. A single `cargo install cargo-generate --locked` is enough now; no `pkg-config`, `libgit2`, `libssl-dev`, `perl`, or C compiler required.
- **`usage/git-over-ssh.md`** — replaces the `auth-git2` mechanics with the new reality: cargo-generate delegates SSH to the system `ssh` binary, so `ssh-agent`, `~/.ssh/config` (`IdentityFile`, `IdentitiesOnly`, `ProxyJump`, …), default identity discovery, and passphrase prompts all just work. `-i` / `--identity` still works via an in-memory `core.sshCommand` override (equivalent to `GIT_SSH_COMMAND`).

## Numbers

`-67 / +49` across 2 files. Local `mdbook build` clean.

## Expected iteration

Splitting docs off deliberately so we can iterate on wording, examples, and any follow-up chapters (short-SHA behaviour, submodule notes, migration guide from libgit2-era) without churning the code PRs.