### PR TITLE
chore(deps): drop gix-hash and gix-config as direct dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,6 @@ dependencies = [
  "fs-err",
  "gix",
  "gix-config",
- "gix-hash",
  "heck",
  "home",
  "ignore",
@@ -325,12 +324,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -401,9 +400,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -478,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1962,9 +1961,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2141,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -3836,9 +3835,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,6 @@ dependencies = [
  "env_logger",
  "fs-err",
  "gix",
- "gix-config",
  "heck",
  "home",
  "ignore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ console = "~0.16"
 dialoguer = "~0.12"
 env_logger = "~0.11"
 fs-err = "~3.3"
-gix-config = "~0.60"
+gix-config = { version = "~0.60", features = ["sha1"] }
 gix = { version = "~0.87", default-features = false, features = [
     "sha1",
     "revision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ dialoguer = "~0.12"
 env_logger = "~0.11"
 fs-err = "~3.3"
 gix-config = "~0.60"
-# gix-config's transitive deps need gix-hash with a hash-kind feature enabled;
-# otherwise gix-hash's Kind enum is empty and the crate fails to compile.
-gix-hash = { version = "~0.26", default-features = false, features = ["sha1"] }
-# for the gix module, that will be a drop-in replacement for git2
 gix = { version = "~0.87", default-features = false, features = [
     "sha1",
     "revision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ console = "~0.16"
 dialoguer = "~0.12"
 env_logger = "~0.11"
 fs-err = "~3.3"
-gix-config = { version = "~0.60", features = ["sha1"] }
 gix = { version = "~0.87", default-features = false, features = [
     "sha1",
     "revision",

--- a/src/git/gitconfig.rs
+++ b/src/git/gitconfig.rs
@@ -1,7 +1,7 @@
 use crate::git::utils::home;
 use anyhow::Context;
 use anyhow::Result;
-use gix_config::{File as GitConfigParser, Source};
+use gix::config::{File as GitConfigParser, Source};
 use std::path::{Path, PathBuf};
 
 pub fn find_gitconfig() -> Result<Option<PathBuf>> {

--- a/src/template_variables/authors.rs
+++ b/src/template_variables/authors.rs
@@ -24,7 +24,7 @@ pub fn get_authors() -> Result<Authors> {
                 }
             }
         }
-        gix_config::File::from_globals()
+        gix::config::File::from_globals()
             .ok()
             .and_then(|file| file.string(key).map(|v| v.to_string()))
     }

--- a/tests/integration/git.rs
+++ b/tests/integration/git.rs
@@ -1,5 +1,5 @@
 use bstr::ByteSlice;
-use gix_config::File as GitConfig;
+use gix::config::File as GitConfig;
 
 use crate::helpers::prelude::*;
 

--- a/tests/integration/git.rs
+++ b/tests/integration/git.rs
@@ -1,6 +1,5 @@
 use bstr::ByteSlice;
 use gix_config::File as GitConfig;
-use std::ops::Deref;
 
 use crate::helpers::prelude::*;
 
@@ -140,7 +139,7 @@ fn should_retrieve_an_instead_of_url() {
     let url = config
         .string_by("url", Some("ssh://git@github.com:".into()), "insteadOf")
         .unwrap();
-    assert_eq!(url.deref().as_bstr(), "https://github.com/");
+    assert_eq!(url, "https://github.com/");
     config
         .set_raw_value_by(
             "url",


### PR DESCRIPTION
## Why

Both `gix-hash` and `gix-config` were carried as direct dependencies but neither is actually needed alongside `gix`:

- `gix` re-exports `gix_hash` as `gix::hash` and `gix_config` as `gix::config` (unconditionally — no extra feature flag).
- `gix-config`'s `sha1` feature is a passthrough to `gix-hash/sha1`, which our `gix` feature set (`sha1`) already enables. So no capability is lost by dropping it.

## Impact

- Two fewer dependency lines and versions to keep in sync with the `gix` ecosystem.
- Removes the class of "feature-resolution" fixes that repeatedly needed adjustment when transitive gix crates evolved (see the comment we used to carry about `gix-hash` `Kind` being empty, and the recent `gix-config` sha1 patch).
- No behaviour change — call sites now use `gix::config::{File, Source}` and the equivalent for hash types. Full test suite green locally, including the `git::` integration tests.

## Test plan

- [x] `cargo build --all` clean
- [x] `cargo test --locked --all git` — all 19 unit + 16 integration git tests pass, including `should_resolve_instead_url` and `should_retrieve_an_instead_of_url`
- [ ] CI green