### PR TITLE
docs: add Library Usage chapter to the mdbook guide

### DIFF
--- a/examples/how-to-use-cargo-gen-as-library/src/main.rs
+++ b/examples/how-to-use-cargo-gen-as-library/src/main.rs
@@ -1,4 +1,6 @@
+// ANCHOR: imports
 use cargo_generate::{generate, GenerateArgs, TemplatePath, Vcs};
+// ANCHOR_END: imports
 
 fn main() {
     // We use wasm-pack as in the README example,
@@ -6,6 +8,7 @@ fn main() {
     // ```sh
     // cargo generate --git https://github.com/rustwasm/wasm-pack-template.git --name my-project
     // ```
+    // ANCHOR: build_args
     let wasm_pack_args = GenerateArgs {
         name: Some("my-project".to_string()),
         vcs: Some(Vcs::Git),
@@ -15,6 +18,9 @@ fn main() {
         },
         ..GenerateArgs::default()
     };
+    // ANCHOR_END: build_args
 
-    let path = generate(wasm_pack_args).expect("something went wrong!");
+    // ANCHOR: call
+    let _path = generate(wasm_pack_args).expect("something went wrong!");
+    // ANCHOR_END: call
 }

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Usage](usage/README.md)
   - [Git over SSH](usage/git-over-ssh.md)
   - [.gitconfig `insteadOf`](usage/gitconfig-instead-of.md)
+- [Library Usage](library-usage.md)
 - [Favorites](favorites.md)
 - [Templates](templates/README.md)
   - [Builtin Placeholders](templates/builtin_placeholders.md)

--- a/guide/src/library-usage.md
+++ b/guide/src/library-usage.md
@@ -1,0 +1,77 @@
+# Library Usage
+
+`cargo-generate` is also a Rust library. Any binary or library crate can depend
+on it and drive template generation programmatically — the same code path the
+`cargo generate` CLI uses under the hood.
+
+The canonical worked example lives in the repository at
+[`examples/how-to-use-cargo-gen-as-library/`][ex]. This chapter walks through
+its pieces, pulling the snippets straight from that file so they can never drift
+apart.
+
+## Depend on `cargo-generate`
+
+Add the crate to your `Cargo.toml`. Turning `default-features` off keeps your
+build free of the CLI-only feature gates:
+
+```toml
+[dependencies]
+cargo-generate = { version = "*", default-features = false }
+```
+
+## Imports
+
+Three types cover the common cases:
+
+```rust
+{{#include ../../examples/how-to-use-cargo-gen-as-library/src/main.rs:imports}}
+```
+
+* [`GenerateArgs`] mirrors the top-level CLI arguments.
+* [`TemplatePath`] describes where the template comes from — a git url, a local
+  path, a favorite, etc.
+* [`Vcs`] controls what version control system (if any) is initialized in the
+  generated project.
+
+## 1. Build a `GenerateArgs`
+
+Populate only the fields you care about; everything else falls back to
+`GenerateArgs::default()` / `TemplatePath::default()`:
+
+```rust
+{{#include ../../examples/how-to-use-cargo-gen-as-library/src/main.rs:build_args}}
+```
+
+The example above is equivalent to running the CLI as:
+
+```sh
+cargo generate --git https://github.com/rustwasm/wasm-pack-template.git --name my-project
+```
+
+## 2. Call `generate`
+
+`generate` runs the same flow the CLI would — clone the template, expand
+placeholders, honor hooks, and (if a VCS is requested) initialize the new
+repository. On success it returns the [`PathBuf`] of the generated project:
+
+```rust
+{{#include ../../examples/how-to-use-cargo-gen-as-library/src/main.rs:call}}
+```
+
+## Running the example
+
+From a checkout of this repository:
+
+```sh
+cd examples/how-to-use-cargo-gen-as-library
+cargo run
+```
+
+You will end up with a freshly generated `my-project/` in the current
+directory, exactly as if you had invoked `cargo generate` yourself.
+
+[ex]: https://github.com/cargo-generate/cargo-generate/tree/main/examples/how-to-use-cargo-gen-as-library
+[`GenerateArgs`]: https://docs.rs/cargo-generate/latest/cargo_generate/struct.GenerateArgs.html
+[`TemplatePath`]: https://docs.rs/cargo-generate/latest/cargo_generate/struct.TemplatePath.html
+[`Vcs`]: https://docs.rs/cargo-generate/latest/cargo_generate/enum.Vcs.html
+[`PathBuf`]: https://doc.rust-lang.org/std/path/struct.PathBuf.html

--- a/guide/src/library-usage.md
+++ b/guide/src/library-usage.md
@@ -1,18 +1,17 @@
 # Library Usage
 
-`cargo-generate` is also a Rust library. Any binary or library crate can depend
-on it and drive template generation programmatically — the same code path the
-`cargo generate` CLI uses under the hood.
+`cargo-generate` is also a Rust library. Any crate can depend on it and drive
+template generation from code, using the same path as the `cargo generate` CLI.
 
-The canonical worked example lives in the repository at
-[`examples/how-to-use-cargo-gen-as-library/`][ex]. This chapter walks through
-its pieces, pulling the snippets straight from that file so they can never drift
-apart.
+A full worked example lives in this repository at
+[`examples/how-to-use-cargo-gen-as-library/`][ex]. The snippets below are
+pulled straight from that file with mdbook's `{{#include}}`, so they cannot
+drift out of sync.
 
 ## Depend on `cargo-generate`
 
-Add the crate to your `Cargo.toml`. Turning `default-features` off keeps your
-build free of the CLI-only feature gates:
+Add the crate to your `Cargo.toml`. Turning `default-features` off keeps the
+CLI-only feature gates out of your build:
 
 ```toml
 [dependencies]
@@ -28,9 +27,9 @@ Three types cover the common cases:
 ```
 
 * [`GenerateArgs`] mirrors the top-level CLI arguments.
-* [`TemplatePath`] describes where the template comes from — a git url, a local
+* [`TemplatePath`] describes where the template comes from: a git url, a local
   path, a favorite, etc.
-* [`Vcs`] controls what version control system (if any) is initialized in the
+* [`Vcs`] controls which version control system (if any) is initialized in the
   generated project.
 
 ## 1. Build a `GenerateArgs`
@@ -42,7 +41,7 @@ Populate only the fields you care about; everything else falls back to
 {{#include ../../examples/how-to-use-cargo-gen-as-library/src/main.rs:build_args}}
 ```
 
-The example above is equivalent to running the CLI as:
+The example above is equivalent to running:
 
 ```sh
 cargo generate --git https://github.com/rustwasm/wasm-pack-template.git --name my-project
@@ -50,8 +49,8 @@ cargo generate --git https://github.com/rustwasm/wasm-pack-template.git --name m
 
 ## 2. Call `generate`
 
-`generate` runs the same flow the CLI would — clone the template, expand
-placeholders, honor hooks, and (if a VCS is requested) initialize the new
+`generate` runs the same flow as the CLI: clone the template, expand
+placeholders, run hooks, and (if a VCS is requested) initialize the new
 repository. On success it returns the [`PathBuf`] of the generated project:
 
 ```rust
@@ -67,8 +66,8 @@ cd examples/how-to-use-cargo-gen-as-library
 cargo run
 ```
 
-You will end up with a freshly generated `my-project/` in the current
-directory, exactly as if you had invoked `cargo generate` yourself.
+This creates a `my-project/` directory in the current folder, the same result
+you would get from running `cargo generate` on the command line.
 
 [ex]: https://github.com/cargo-generate/cargo-generate/tree/main/examples/how-to-use-cargo-gen-as-library
 [`GenerateArgs`]: https://docs.rs/cargo-generate/latest/cargo_generate/struct.GenerateArgs.html


### PR DESCRIPTION
## Why

- New chapter documents `cargo-generate`'s public library API, so consumers embedding it in their own tools don't need to reverse-engineer the example.
- Snippets are pulled from `examples/how-to-use-cargo-gen-as-library/` via mdbook's `{{#include}}` preprocessor, so the docs cannot drift from the compiled, tested example.
- Example is now warning-clean (`path` → `_path`) so the include stays green.