### PR TITLE
ci: migrate gh-pages deploy to first-party Pages Actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,25 +7,41 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v7
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v2
         with:
-          # mdbook-version: '0.4.15'
-          mdbook-version: 'latest'
+          mdbook-version: '0.5.4'
 
       - run: cd guide && mdbook build
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.CI_CARGO_GENERATE_RELEASE_GH_PAT }} 
-          publish_dir: ./guide/book
+          path: ./guide/book
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Why

- Previous deploy authenticated with `CI_CARGO_GENERATE_RELEASE_GH_PAT` and pushed to a `gh-pages` branch (via `peaceiris/actions-gh-pages`). The PAT expired and broke the last deploy on main — that pattern will keep breaking on every rotation.
- GitHub's first-party Pages Actions (`configure-pages` / `upload-pages-artifact` / `deploy-pages`) publish over OIDC, per-run token, no branch push. No PAT to rotate, no `contents: write`, no `gh-pages` branch to carry build artifacts.
- Pins `mdbook-version` to `0.5.4` (was `latest`) so a future mdbook release cannot silently break the build.

## Post-merge action required

Repo Settings → Pages → Build and deployment → **Source: GitHub Actions** (currently "Deploy from a branch"). After the first green deploy, the `gh-pages` branch and the `CI_CARGO_GENERATE_RELEASE_GH_PAT` secret can be deleted.