### PR TITLE
feat: allow --define to override builtin placeholders

### DIFF
--- a/guide/src/templates/builtin_placeholders.md
+++ b/guide/src/templates/builtin_placeholders.md
@@ -36,6 +36,24 @@ Builtin placeholders are:
 * `is_init`
     * A boolean that reflects the value of the `--init` parameter of `cargo-generate`.
 
+## Overriding builtin placeholders
+
+> Available since version [0.24.0](https://github.com/cargo-generate/cargo-generate/releases/tag/v0.24.0)
+
+Builtin placeholders can be overridden on the command line via `--define`, the
+`--values-file`, or a `CARGO_GENERATE_VALUE_<NAME>` environment variable — the
+same mechanisms used for template-defined placeholders. This is useful when the
+auto-derived value (e.g. `authors` from local git config) should be pinned to a
+stable value, for example when committing the expanded template to a
+repository.
+
+```sh
+cargo generate --git … --define 'authors=The Project Authors'
+```
+
+An info message is logged whenever a builtin is overridden, so accidental
+overrides remain visible.
+
 ## Usage example
 
 ```markdown

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,20 +619,45 @@ fn expand_template(
     Ok(destination.as_ref().to_owned())
 }
 
+/// Builtin placeholder names that are pre-populated by cargo-generate.
+///
+/// When a value with one of these names is supplied via `--define` (or the
+/// equivalent env/values-file mechanisms), it overrides the value that was
+/// derived automatically. An info message is emitted so that accidental
+/// overrides don't go unnoticed.
+const BUILTIN_PLACEHOLDER_NAMES: &[&str] = &[
+    "authors",
+    "username",
+    "os-arch",
+    "project-name",
+    "crate_name",
+    "crate_type",
+    "within_cargo_project",
+    "is_init",
+];
+
 /// Try to add all provided `template_values` to the `liquid_object`.
 ///
-/// ## Note:
-/// Values for which a placeholder exists, should already be filled by `fill_project_variables`
+/// Values for which a placeholder exists should already be filled by
+/// `fill_project_variables`; those are skipped here. Builtin placeholders
+/// (see [`BUILTIN_PLACEHOLDER_NAMES`]) are intentionally overwritten so that
+/// `--define authors=…` and friends work — an info message is logged whenever
+/// this happens so accidental overrides are visible.
 pub(crate) fn add_missing_provided_values(
     liquid_object: &LiquidObjectResource,
     template_values: &HashMap<String, toml::Value>,
 ) -> Result<(), anyhow::Error> {
     template_values.iter().try_for_each(|(k, v)| {
-        if RefCell::borrow(&liquid_object.lock().unwrap()).contains_key(k.as_str()) {
+        let already_present =
+            RefCell::borrow(&liquid_object.lock().unwrap()).contains_key(k.as_str());
+        let is_builtin = BUILTIN_PLACEHOLDER_NAMES.contains(&k.as_str());
+
+        // A non-builtin value that is already set was filled by placeholder
+        // handling — don't clobber it.
+        if already_present && !is_builtin {
             return Ok(());
         }
-        // we have a value without a slot in the liquid object.
-        // try to create the slot from the provided value
+
         let value = match v {
             toml::Value::String(content) => liquid_core::Value::Scalar(content.clone().into()),
             toml::Value::Boolean(content) => liquid_core::Value::Scalar((*content).into()),
@@ -644,6 +669,19 @@ pub(crate) fn add_missing_provided_values(
                     .red(),
             )),
         };
+
+        if already_present && is_builtin {
+            info!(
+                "{} {}",
+                emoji::WARN,
+                style(format!(
+                    "Overriding builtin placeholder `{k}` with value from `--define`"
+                ))
+                .bold()
+                .yellow(),
+            );
+        }
+
         liquid_object
             .lock()
             .unwrap()

--- a/tests/integration/basics.rs
+++ b/tests/integration/basics.rs
@@ -1008,3 +1008,118 @@ fn test_flag_with_github_shorthand_clones_remote() {
                 .from_utf8(),
         );
 }
+
+#[test]
+fn it_overrides_builtin_authors_placeholder_via_define() {
+    let template = tempdir()
+        .file(
+            "Cargo.toml",
+            indoc! {r#"
+                [package]
+                name = "{{project-name}}"
+                description = "authors = {{authors}}"
+                version = "0.1.0"
+            "#},
+        )
+        .init_git()
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg_git(template.path())
+        .arg_name("foobar-project")
+        .arg_branch("main")
+        .args(["--define", "authors=The Project Authors"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(
+            predicates::str::contains(
+                "Overriding builtin placeholder `authors` with value from `--define`",
+            )
+            .from_utf8(),
+        );
+
+    assert!(dir
+        .read("foobar-project/Cargo.toml")
+        .contains("authors = The Project Authors"));
+}
+
+#[test]
+fn it_overrides_builtin_os_arch_placeholder_via_define() {
+    let template = tempdir()
+        .file(
+            "Cargo.toml",
+            indoc! {r#"
+                [package]
+                name = "{{project-name}}"
+                description = "os-arch = {{os-arch}}"
+                version = "0.1.0"
+            "#},
+        )
+        .init_git()
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg_git(template.path())
+        .arg_name("foobar-project")
+        .arg_branch("main")
+        .args(["--define", "os-arch=custom-target"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(
+            predicates::str::contains(
+                "Overriding builtin placeholder `os-arch` with value from `--define`",
+            )
+            .from_utf8(),
+        );
+
+    assert!(dir
+        .read("foobar-project/Cargo.toml")
+        .contains("os-arch = custom-target"));
+}
+
+#[test]
+fn it_does_not_warn_when_define_matches_user_placeholder() {
+    let template = tempdir()
+        .file(
+            "cargo-generate.toml",
+            indoc! {r#"
+                [placeholders.greeting]
+                type = "string"
+                prompt = "greeting?"
+                default = "hi"
+            "#},
+        )
+        .file(
+            "Cargo.toml",
+            indoc! {r#"
+                [package]
+                name = "{{project-name}}"
+                description = "greeting = {{greeting}}"
+                version = "0.1.0"
+            "#},
+        )
+        .init_git()
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg_git(template.path())
+        .arg_name("foobar-project")
+        .arg_branch("main")
+        .args(["--define", "greeting=hello"])
+        .current_dir(dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Overriding builtin placeholder").not());
+
+    assert!(dir
+        .read("foobar-project/Cargo.toml")
+        .contains("greeting = hello"));
+}


### PR DESCRIPTION
- users can now pin builtins like `authors` or `os-arch` via `--define` instead of setting `CARGO_NAME`/`CARGO_EMAIL` (and equivalents) for every builtin individually
- unblocks committing expanded templates to a repo where auto-derived per-machine values (e.g. `authors` from local git config) would otherwise cause churn on every regeneration
- overrides emit an info message so an accidental clobber (e.g. typo in a user placeholder name that happens to match a builtin) stays visible
- will be released with `v0.24.0` 
- documented in the mdbook guide under *Overriding builtin placeholders*.

Closes #1602