### PR TITLE
feat: honor gitconfig http.proxy for http, https and socks5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "predicates",
  "regex",
  "remove_dir_all",
+ "reqwest",
  "rhai",
  "sanitize-filename",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ log = "~0.4"
 names = { version = "~0.14", default-features = false }
 pastey = "~0.2"
 regex = "~1.12"
+# Not imported directly, we only depend on it to union the `socks` feature into
+# the transitive reqwest that gix's blocking-http-transport-reqwest-* pulls in for our proxy support feature.
+reqwest = { version = "~0.13", default-features = false, features = ["socks"] }
 remove_dir_all = "~1.0"
 rhai = "~1.25"
 sanitize-filename = "~0.6"

--- a/src/git/gitconfig.rs
+++ b/src/git/gitconfig.rs
@@ -4,6 +4,18 @@ use anyhow::Result;
 use gix::config::{File as GitConfigParser, Source};
 use std::path::{Path, PathBuf};
 
+/// Effective proxy settings pulled from a gitconfig file.
+///
+/// Fields mirror the two git config keys we care about: `http.proxy` and
+/// `http.noProxy`. Absent keys yield `None`; empty values are preserved as
+/// `Some(String::new())` so callers can distinguish "unset" from git's
+/// "explicitly disabled" convention (`http.proxy = ""`).
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct HttpProxyConfig {
+    pub proxy: Option<String>,
+    pub no_proxy: Option<String>,
+}
+
 pub fn find_gitconfig() -> Result<Option<PathBuf>> {
     let gitconfig = home().map(|home| home.join(".gitconfig"))?;
     if gitconfig.exists() {
@@ -46,6 +58,24 @@ pub fn resolve_instead_url(
     Ok(x)
 }
 
+/// Read `http.proxy` and `http.noProxy` from the given gitconfig file.
+pub fn resolve_http_proxy(gitconfig: impl AsRef<Path>) -> Result<HttpProxyConfig> {
+    let path = gitconfig.as_ref().to_path_buf();
+    let config = GitConfigParser::from_path_no_includes(path, Source::User)
+        .context("Cannot read or parse .gitconfig")?;
+
+    let read = |key: &str| {
+        config
+            .string(key)
+            .map(|v| String::from_utf8_lossy(&v).into_owned())
+    };
+
+    Ok(HttpProxyConfig {
+        proxy: read("http.proxy"),
+        no_proxy: read("http.noProxy"),
+    })
+}
+
 #[cfg(test)]
 mod test {
     use crate::tmp_dir;
@@ -65,5 +95,63 @@ mod test {
         // SSH, aka git@github.com: or ssh://git@github.com/
         let x = resolve_instead_url("https://github.com/foo/bar.git", &gitconfig).unwrap();
         assert_eq!(x.unwrap().as_str(), "ssh://git@github.com:foo/bar.git")
+    }
+
+    fn write_config(body: &str) -> (tempfile::TempDir, PathBuf) {
+        let dir = tmp_dir().unwrap();
+        let path = dir.path().join(".gitconfig");
+        std::fs::write(&path, body).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn resolve_http_proxy_returns_none_when_unset() {
+        let (_dir, cfg) = write_config("");
+        let got = resolve_http_proxy(&cfg).unwrap();
+        assert_eq!(got, HttpProxyConfig::default());
+    }
+
+    #[test]
+    fn resolve_http_proxy_reads_http_proxy() {
+        let (_dir, cfg) = write_config(
+            r#"
+[http]
+    proxy = http://proxy.internal:3128
+"#,
+        );
+        let got = resolve_http_proxy(&cfg).unwrap();
+        assert_eq!(got.proxy.as_deref(), Some("http://proxy.internal:3128"));
+        assert!(got.no_proxy.is_none());
+    }
+
+    #[test]
+    fn resolve_http_proxy_reads_socks5_scheme() {
+        // Regression guard for cargo-generate#664 — socks5 in http.proxy must be
+        // exposed verbatim; the shim later routes it into ALL_PROXY for reqwest.
+        let (_dir, cfg) = write_config(
+            r#"
+[http]
+    proxy = socks5://127.0.0.1:1081
+"#,
+        );
+        let got = resolve_http_proxy(&cfg).unwrap();
+        assert_eq!(got.proxy.as_deref(), Some("socks5://127.0.0.1:1081"));
+    }
+
+    #[test]
+    fn resolve_http_proxy_reads_no_proxy() {
+        let (_dir, cfg) = write_config(
+            r#"
+[http]
+    proxy = http://p:8080
+    noProxy = localhost,127.0.0.1,.internal
+"#,
+        );
+        let got = resolve_http_proxy(&cfg).unwrap();
+        assert_eq!(got.proxy.as_deref(), Some("http://p:8080"));
+        assert_eq!(
+            got.no_proxy.as_deref(),
+            Some("localhost,127.0.0.1,.internal")
+        );
     }
 }

--- a/src/gix/mod.rs
+++ b/src/gix/mod.rs
@@ -53,16 +53,19 @@ impl RepoCloneBuilder {
     }
 
     /// Uses `gitcfg` (or auto-discovered `~/.gitconfig`) to rewrite the clone url
-    /// through any matching `[url "…"] insteadOf` entries.
+    /// through any matching `[url "…"] insteadOf` entries, and to bridge
+    /// `http.proxy` / `http.noProxy` into the `ALL_PROXY` / `NO_PROXY` env vars
+    /// that gix's reqwest transport reads. Env vars set by the shell always win.
     pub fn with_gitconfig(mut self, gitcfg: Option<&Path>) -> Result<Self> {
         if let Some(gitconfig) = gitcfg
             .map(|p| p.to_owned())
             .or_else(|| gitconfig::find_gitconfig().ok().flatten())
         {
-            if let Some(url) = gitconfig::resolve_instead_url(&self.url, gitconfig)? {
+            if let Some(url) = gitconfig::resolve_instead_url(&self.url, &gitconfig)? {
                 debug!("{} gitconfig 'insteadOf' lead to this url: {}", WRENCH, url);
                 self.url = url;
             }
+            apply_proxy_from_gitconfig(&gitconfig)?;
         }
         Ok(self)
     }
@@ -363,6 +366,53 @@ pub fn try_get_branch_from_path(path: impl AsRef<Path>) -> Option<String> {
 /// The `sh -c` interpreter that gix uses for `core.sshCommand` will unquote this back.
 fn sh_single_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Bridge `http.proxy` / `http.noProxy` from `gitconfig` to the env vars reqwest
+/// consults (`ALL_PROXY`, `NO_PROXY`). gix's reqwest transport does not read git
+/// config directly, so without this shim these settings are silently ignored.
+///
+/// Shell env always wins: if any of `ALL_PROXY` / `HTTPS_PROXY` / `HTTP_PROXY`
+/// is already set, the gitconfig `http.proxy` is left as-is. The reasoning is
+/// that a user who exported an env var meant those to be used, overriding would surprise them.
+fn apply_proxy_from_gitconfig(gitconfig: &Path) -> Result<()> {
+    let cfg = gitconfig::resolve_http_proxy(gitconfig)?;
+
+    if let Some(proxy) = cfg.proxy.as_deref().filter(|v| !v.is_empty()) {
+        if any_proxy_env_var_set() {
+            debug!("{WRENCH} skipping gitconfig 'http.proxy'; a proxy env var is already set");
+        } else {
+            debug!("{WRENCH} applying gitconfig 'http.proxy' -> ALL_PROXY = {proxy}");
+            // SAFETY: cargo-generate is single-threaded at this call site — the
+            // gix reqwest worker is only spawned on the first fetch, which
+            // happens later in do_clone().
+            std::env::set_var("ALL_PROXY", proxy);
+        }
+    }
+
+    if let Some(no_proxy) = cfg.no_proxy.as_deref().filter(|v| !v.is_empty()) {
+        if std::env::var_os("NO_PROXY").is_some() || std::env::var_os("no_proxy").is_some() {
+            debug!("{WRENCH} skipping gitconfig 'http.noProxy'; NO_PROXY env var is already set");
+        } else {
+            debug!("{WRENCH} applying gitconfig 'http.noProxy' -> NO_PROXY = {no_proxy}");
+            std::env::set_var("NO_PROXY", no_proxy);
+        }
+    }
+
+    Ok(())
+}
+
+fn any_proxy_env_var_set() -> bool {
+    [
+        "ALL_PROXY",
+        "all_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+    ]
+    .iter()
+    .any(|k| std::env::var_os(k).is_some())
 }
 
 #[cfg(test)]

--- a/tests/integration/helpers/fake_proxy.rs
+++ b/tests/integration/helpers/fake_proxy.rs
@@ -1,0 +1,58 @@
+//! A dumb TCP listener used by the proxy integration tests.
+//!
+//! It is not a real proxy — it accepts a connection, records that fact,
+//! reads/discards a handful of bytes, then closes. That is enough for a
+//! `cargo-generate` subprocess to prove that its clone attempt was routed
+//! through the listener's address rather than going direct, which is the
+//! only claim these tests make.
+//!
+//! Works uniformly for `http://`, `https://` and `socks5://` proxy URLs
+//! because the assertion happens at the TCP-accept layer, below any of the
+//! respective handshakes.
+
+use std::io::Read;
+use std::net::{SocketAddr, TcpListener};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+pub struct FakeProxy {
+    addr: SocketAddr,
+    hit: Arc<AtomicBool>,
+    // Keeps the accept loop alive for the lifetime of this handle; joined on drop.
+    _thread: Option<JoinHandle<()>>,
+}
+
+impl FakeProxy {
+    pub fn spawn() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fake proxy");
+        let addr = listener.local_addr().expect("local addr");
+        let hit = Arc::new(AtomicBool::new(false));
+        let hit_c = hit.clone();
+
+        let thread = std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                hit_c.store(true, Ordering::SeqCst);
+                let mut buf = [0u8; 128];
+                let _ = stream.read(&mut buf);
+                // Drop closes the connection; the client sees EOF.
+            }
+        });
+
+        Self {
+            addr,
+            hit,
+            _thread: Some(thread),
+        }
+    }
+
+    pub fn was_hit(&self) -> bool {
+        self.hit.load(Ordering::SeqCst)
+    }
+
+    /// A `host:port` string suitable for embedding in a proxy URL.
+    pub fn authority(&self) -> String {
+        self.addr.to_string()
+    }
+}

--- a/tests/integration/helpers/mod.rs
+++ b/tests/integration/helpers/mod.rs
@@ -3,6 +3,7 @@ use crate::helpers::project_builder::tempdir;
 use indoc::indoc;
 
 pub mod arg_builder;
+pub mod fake_proxy;
 pub mod prelude;
 pub mod project;
 pub mod project_builder;

--- a/tests/integration/helpers/prelude.rs
+++ b/tests/integration/helpers/prelude.rs
@@ -1,5 +1,6 @@
 pub use crate::helpers::arg_builder::*;
 pub use crate::helpers::create_template;
+pub use crate::helpers::fake_proxy::FakeProxy;
 pub use crate::helpers::project::Project;
 pub use crate::helpers::project_builder::tempdir;
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -10,6 +10,7 @@ mod git_instead_of;
 #[cfg(e2e_tests_with_ssh_key)]
 mod git_over_ssh;
 mod hooks_and_rhai;
+mod proxy;
 mod public_api;
 mod template_config_file;
 mod template_filters;

--- a/tests/integration/proxy.rs
+++ b/tests/integration/proxy.rs
@@ -1,0 +1,108 @@
+//! End-to-end tests for [`gitconfig`] `http.proxy` support.
+//!
+//! Each test writes a scratch `gitconfig` file with `http.proxy` pointing at a
+//! [`FakeProxy`] listening on a random localhost port, invokes `cargo-generate`
+//! against a dummy git URL, and asserts the fake proxy received a connection.
+//!
+//! The clone always fails (the fake proxy closes the socket immediately) —
+//! that is expected. The assertion is that the connection was *routed through
+//! the proxy*, not that it succeeded. Every proxy-related env var is scrubbed
+//! from the subprocess so a developer's shell state cannot poison the result.
+
+use crate::helpers::prelude::*;
+use indoc::formatdoc;
+
+const DUMMY_GIT_URL: &str = "https://github.com/cargo-generate/does-not-exist.git";
+
+const PROXY_ENV_KEYS: &[&str] = &[
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+    "NO_PROXY",
+    "no_proxy",
+];
+
+fn write_gitconfig_with_proxy(scheme: &str, authority: &str) -> Project {
+    tempdir()
+        .file(
+            ".gitconfig",
+            formatdoc! { r#"
+                [http]
+                    proxy = {scheme}://{authority}
+            "# },
+        )
+        .build()
+}
+
+fn run_generate(gitconfig: PathBuf, cwd: PathBuf) -> assert_cmd::assert::Assert {
+    let mut cmd = binary();
+    cmd.arg_gitconfig(gitconfig)
+        .arg_git(DUMMY_GIT_URL)
+        .arg_name("proxy-test");
+    let command = cmd.current_dir(cwd);
+    for key in PROXY_ENV_KEYS {
+        command.env_remove(key);
+    }
+    command.assert()
+}
+
+#[test]
+fn http_proxy_in_gitconfig_is_honored() {
+    let proxy = FakeProxy::spawn();
+    let gitconfig_dir = write_gitconfig_with_proxy("http", &proxy.authority());
+    let target = tempdir().build();
+
+    run_generate(
+        gitconfig_dir.path().join(".gitconfig"),
+        target.path().to_path_buf(),
+    )
+    .failure();
+
+    assert!(
+        proxy.was_hit(),
+        "cargo-generate did not route through http.proxy = http://{} — the gitconfig proxy shim is not wiring up",
+        proxy.authority()
+    );
+}
+
+#[test]
+fn https_proxy_in_gitconfig_is_honored() {
+    let proxy = FakeProxy::spawn();
+    let gitconfig_dir = write_gitconfig_with_proxy("https", &proxy.authority());
+    let target = tempdir().build();
+
+    run_generate(
+        gitconfig_dir.path().join(".gitconfig"),
+        target.path().to_path_buf(),
+    )
+    .failure();
+
+    assert!(
+        proxy.was_hit(),
+        "cargo-generate did not route through http.proxy = https://{} — the gitconfig proxy shim is not wiring up",
+        proxy.authority()
+    );
+}
+
+#[test]
+fn socks5_proxy_in_gitconfig_is_honored() {
+    let proxy = FakeProxy::spawn();
+    let gitconfig_dir = write_gitconfig_with_proxy("socks5", &proxy.authority());
+    let target = tempdir().build();
+
+    run_generate(
+        gitconfig_dir.path().join(".gitconfig"),
+        target.path().to_path_buf(),
+    )
+    .failure();
+
+    assert!(
+        proxy.was_hit(),
+        "cargo-generate did not route through http.proxy = socks5://{} — either the shim is not wiring up, \
+         or reqwest was not built with the `socks` feature",
+        proxy.authority()
+    );
+}


### PR DESCRIPTION
## Summary

- restores parity with the git2 backend: `git config --global http.proxy …` again routes cargo-generate clones through the proxy
- adds socks5 support via `reqwest`'s `socks` feature union, closing the tail of #664 that the gix migration left dangling
- shell env (`ALL_PROXY` / `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY`) still wins over gitconfig, matching git's own precedence rule

## Why

The migration to `gix` (#1460, #1749) replaced libgit2's proxy handling with a reqwest transport that has **no** proxy hooks in gix 0.87 — its `http::Options.proxy` field is only consumed by the curl backend. Result: `http.proxy` in gitconfig was silently ignored by cargo-generate, and users behind corporate proxies or SOCKS5 setups had to export shell env vars to work around it.

This PR bridges `http.proxy` / `http.noProxy` into the process env before gix spins up its reqwest client, and enables reqwest's `socks` feature via a direct-dep feature union so `socks5://` in `http.proxy` works too.

Closes #1760.

## Test plan

- [x] `cargo test --all --locked` — 200 lib tests, 121 integration tests, 0 failures
- [x] `cargo clippy --locked --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] new integration tests exercise `http://`, `https://`, `socks5://` values of `http.proxy` end-to-end against a fake TCP proxy listener
- [x] new unit tests cover `resolve_http_proxy` for present, absent, socks5, and `noProxy` cases