### PR TITLE
fix: skip CACHEDIR.TAG directories to speed up template generation

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -1,12 +1,31 @@
 use anyhow::{bail, Ok, Result};
 use console::style;
-use log::{debug, warn};
+use log::{debug, info, warn};
 use std::{
-    fs::{copy, read_dir, remove_file},
+    fs::{copy, read_dir, remove_file, File},
+    io::Read,
     path::Path,
 };
 
 pub const LIQUID_SUFFIX: &str = ".liquid";
+
+// Cache Directory Tagging Specification (https://bford.info/cachedir/).
+// Cargo writes a `CACHEDIR.TAG` file into every `target/` build directory it
+// creates, whose first 43 bytes match `CACHEDIR_TAG_SIGNATURE`. Detecting this
+// marker lets us skip build directories without misidentifying user content.
+const CACHEDIR_TAG_FILE: &str = "CACHEDIR.TAG";
+const CACHEDIR_TAG_SIGNATURE: &[u8; 43] = b"Signature: 8a477f597d28d172789f06886806bc55";
+
+/// Whether `dir` is a cache directory per the Cache Directory Tagging Spec —
+/// i.e. contains a `CACHEDIR.TAG` file whose first 43 bytes are the spec
+/// signature. Any I/O error is treated as "not a cache dir".
+pub fn is_cache_dir(dir: &Path) -> bool {
+    let Some(mut file) = File::open(dir.join(CACHEDIR_TAG_FILE)).ok() else {
+        return false;
+    };
+    let mut buf = [0u8; CACHEDIR_TAG_SIGNATURE.len()];
+    file.read_exact(&mut buf).is_ok() && &buf == CACHEDIR_TAG_SIGNATURE
+}
 
 pub fn copy_files_recursively(
     src: impl AsRef<Path>,
@@ -23,6 +42,16 @@ pub fn copy_files_recursively(
         if entry_type.is_dir() {
             // we skip the .git directory
             if filename == ".git" {
+                continue;
+            }
+            // Skip build cache directories (e.g. cargo's `target/`), walking
+            // them wastes seconds to minutes on a template with a warm build.
+            // See https://github.com/cargo-generate/cargo-generate/issues/1600
+            if is_cache_dir(&src_entry.path()) {
+                info!(
+                    "Skipping cache directory (CACHEDIR.TAG): `{}`",
+                    src_entry.path().display()
+                );
                 continue;
             }
             let dst_dir = dst_path.join(filename);

--- a/src/template.rs
+++ b/src/template.rs
@@ -13,6 +13,7 @@ use std::{
 use walkdir::{DirEntry, WalkDir};
 
 use crate::config::TemplateConfig;
+use crate::copy::is_cache_dir;
 use crate::emoji;
 use crate::filenames::substitute_filename;
 use crate::hooks::PoisonError;
@@ -139,6 +140,9 @@ pub fn walk_dir(
         .sort_by_file_name()
         .contents_first(true)
         .into_iter()
+        // Prune build cache directories (e.g. cargo's `target/`) before we
+        // descend, see https://github.com/cargo-generate/cargo-generate/issues/1600
+        .filter_entry(|e| !(e.file_type().is_dir() && is_cache_dir(e.path())))
         .filter_map(Result::ok)
         .filter(|e| !is_git_metadata(e))
         .filter(|e| e.path() != project_dir)

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -11,6 +11,7 @@ mod git_instead_of;
 mod git_over_ssh;
 mod hooks_and_rhai;
 mod public_api;
+mod target_folder;
 mod template_config_file;
 mod template_filters;
 mod workspace_member;

--- a/tests/integration/target_folder.rs
+++ b/tests/integration/target_folder.rs
@@ -1,0 +1,71 @@
+use crate::helpers::prelude::*;
+
+// A cargo `target/` directory left inside a template must not be walked,
+// templated, or copied into the generated project — otherwise generation
+// is dramatically slowed by incremental build artifacts.
+//
+// Detection is strict: only directories carrying a `CACHEDIR.TAG` marker
+// (the convention cargo writes into every build directory) are skipped, so
+// templates that legitimately ship a `target/` directory of their own are
+// untouched.
+//
+// Regression test for https://github.com/cargo-generate/cargo-generate/issues/1600
+#[test]
+fn issue_1600_target_directory_with_cachedir_tag_is_excluded() {
+    let template = tempdir()
+        .with_default_manifest()
+        .file(
+            "target/CACHEDIR.TAG",
+            "Signature: 8a477f597d28d172789f06886806bc55",
+        )
+        .file("target/debug/deps/libfoo.rlib", "not a real artifact")
+        .file("target/debug/build/foo/output", "cargo build output marker")
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg_name("foobar-project")
+        .arg(template.path())
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let generated_target = dir.path().join("foobar-project").join("target");
+    assert!(
+        !generated_target.exists(),
+        "target/ directory (marked with CACHEDIR.TAG) was copied to the generated \
+         project, indicating cargo-generate is still walking rust build artifacts \
+         (issue #1600)"
+    );
+}
+
+// Counterpart: a `target/` directory that does NOT carry a `CACHEDIR.TAG`
+// marker is a plain user directory and must be preserved. This guards the
+// strict-detection contract against accidental over-matching.
+#[test]
+fn a_plain_target_directory_without_cachedir_tag_is_preserved() {
+    let template = tempdir()
+        .with_default_manifest()
+        .file("target/notes.txt", "user-authored content")
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg_name("foobar-project")
+        .arg(template.path())
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    let generated_notes = dir
+        .path()
+        .join("foobar-project")
+        .join("target")
+        .join("notes.txt");
+    assert!(
+        generated_notes.exists(),
+        "target/ without CACHEDIR.TAG must be treated as a normal directory and copied"
+    );
+}

--- a/tests/integration/target_folder.rs
+++ b/tests/integration/target_folder.rs
@@ -5,9 +5,11 @@ use crate::helpers::prelude::*;
 // is dramatically slowed by incremental build artifacts.
 //
 // Detection is strict: only directories carrying a `CACHEDIR.TAG` marker
-// (the convention cargo writes into every build directory) are skipped, so
-// templates that legitimately ship a `target/` directory of their own are
-// untouched.
+// are skipped, so templates that legitimately ship a `target/` directory
+// of their own are untouched. Cargo has been writing this marker into
+// every build directory since 1.46 — see
+// https://doc.rust-lang.org/cargo/CHANGELOG.html#cargo-146-2020-08-27 and
+// the introducing PR https://github.com/rust-lang/cargo/pull/8378.
 //
 // Regression test for https://github.com/cargo-generate/cargo-generate/issues/1600
 #[test]


### PR DESCRIPTION
Local path templates with a warm cargo `target/` around walked every build artifact three times (initial copy into tempdir, liquid pass, copy to destination). On a multi-GiB target that's tens of seconds of pointless stat/read work per generation.

- Prune directories carrying a `CACHEDIR.TAG` marker (Cache Directory Tagging Spec, cargo writes it into every build dir) from both `copy_files_recursively` and the `walk_dir` walkdir pass
- Strict 43-byte signature check — user-authored `target/` dirs that lack the marker are still copied through
- Regression test `tests/integration/target_folder.rs` locks in both the fix and the strictness contract
- Closes #1600