### PR TITLE
fix: add generated crate to workspace when run from a nested folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "env_logger",
  "fs-err",
  "gix",
+ "glob",
  "heck",
  "home",
  "ignore",
@@ -1755,6 +1756,12 @@ dependencies = [
  "thiserror",
  "zlib-rs",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ time = "~0.3"
 toml = { version = "~1.1", features = ["preserve_order"] }
 walkdir = "~2.5"
 cargo-util-schemas = "~0.14"
+glob = "~0.3"
 
 [dev-dependencies]
 assert_cmd = "~2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,8 +165,13 @@ pub fn generate(args: GenerateArgs) -> Result<PathBuf> {
                         style(workspace_cargo_toml.display()).bold().yellow(),
                     );
                 }
-                WorkspaceMemberStatus::NoWorkspaceFound => {
-                    // not an issue, just a notification
+                WorkspaceMemberStatus::AlreadyCoveredByGlob(_)
+                | WorkspaceMemberStatus::Excluded(_)
+                | WorkspaceMemberStatus::NoWorkspaceFound => {
+                    // AlreadyCoveredByGlob: an existing glob (e.g. `crates/*`) already
+                    // includes the new project, nothing to write. Silent, matching cargo new.
+                    // Excluded: workspace_member::add_to_workspace already logged a warning.
+                    // NoWorkspaceFound: not in a workspace, nothing to do.
                 }
             }
         }

--- a/src/workspace_member.rs
+++ b/src/workspace_member.rs
@@ -1,130 +1,150 @@
+use anyhow::{anyhow, Context, Result};
 use cargo_util_schemas::manifest::TomlManifest;
+use glob::Pattern;
+use log::warn;
 use std::{
     fs,
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, bail, Context, Result};
-use log::warn;
-
 #[derive(Debug, PartialEq)]
 pub enum WorkspaceMemberStatus {
+    /// The new project was appended to the workspace's `members` list.
     Added(PathBuf),
+    /// A workspace root was found, but the new project's directory matches an
+    /// entry in `workspace.exclude`; the manifest was left untouched.
+    Excluded(PathBuf),
+    /// A workspace root was found and the new project is already implicitly
+    /// covered by an existing glob entry in `members`; no manifest change was
+    /// required.
+    AlreadyCoveredByGlob(PathBuf),
+    /// No workspace root was found while walking up the parent directories.
     NoWorkspaceFound,
 }
 
-/// Add the given project to the workspace members list.
-/// If there is no workspace project in the parent directories of the given path, do nothing.
+/// Add the given project to the workspace's `members` list.
+///
+/// Walks up from `member_path` looking for the first `Cargo.toml` that has a
+/// `[workspace]` table, mirroring `cargo new` (see `find_root_manifest_for_wd`
+/// and `update_manifest_with_new_member` in `rust-lang/cargo`).
 pub fn add_to_workspace(member_path: &Path) -> Result<WorkspaceMemberStatus> {
-    let Some(mut workspace) = Workspace::try_new(member_path)? else {
+    let Some(mut workspace) = Workspace::find_root(member_path)? else {
         return Ok(WorkspaceMemberStatus::NoWorkspaceFound);
     };
-    let member = WorkspaceMember::try_new(member_path)?;
-    workspace.add_member(member)?;
-    workspace.save()?;
+    let relative_member_path = workspace.relative_path_for(member_path)?;
 
+    if workspace.is_excluded(&relative_member_path) {
+        warn!(
+            "Project `{}` matches `workspace.exclude` in {}; skipping workspace membership.",
+            relative_member_path,
+            workspace.cargo_toml_path.display()
+        );
+        return Ok(WorkspaceMemberStatus::Excluded(workspace.cargo_toml_path));
+    }
+
+    if workspace.is_covered_by_existing_member(&relative_member_path) {
+        return Ok(WorkspaceMemberStatus::AlreadyCoveredByGlob(
+            workspace.cargo_toml_path,
+        ));
+    }
+
+    workspace.append_member(relative_member_path)?;
+    workspace.save()?;
     Ok(WorkspaceMemberStatus::Added(workspace.cargo_toml_path))
 }
 
 struct Workspace {
     manifest: TomlManifest,
     cargo_toml_path: PathBuf,
+    root_dir: PathBuf,
 }
 
 impl Workspace {
-    /// Try to find a workspace project in the parent directories of the given path.
-    ///
-    /// Returns `None` if no workspace project is found.
-    pub fn try_new(member_path: &Path) -> Result<Option<Self>> {
-        if let Some(parent) = member_path.parent() {
-            let cargo_toml_path = parent.join("Cargo.toml");
-            if cargo_toml_path.exists() {
-                let content = fs::read_to_string(&cargo_toml_path)?;
-                let manifest: TomlManifest = toml::from_str(&content)
-                    .with_context(|| format!("Failed to parse {}", cargo_toml_path.display()))?;
-                if manifest.workspace.is_some()
-                    && manifest.workspace.as_ref().unwrap().members.is_some()
-                {
-                    return Ok(Some(Self {
-                        manifest,
-                        cargo_toml_path,
-                    }));
-                }
+    fn find_root(member_path: &Path) -> Result<Option<Self>> {
+        for ancestor in member_path.ancestors().skip(1) {
+            let cargo_toml_path = ancestor.join("Cargo.toml");
+            if !cargo_toml_path.exists() {
+                continue;
+            }
+            let content = fs::read_to_string(&cargo_toml_path)?;
+            let manifest: TomlManifest = toml::from_str(&content)
+                .with_context(|| format!("Failed to parse {}", cargo_toml_path.display()))?;
+            if manifest.workspace.is_some() {
+                return Ok(Some(Self {
+                    manifest,
+                    cargo_toml_path,
+                    root_dir: ancestor.to_path_buf(),
+                }));
             }
         }
-
         Ok(None)
     }
 
-    /// Add a new member to the workspace, if it is not already a member.
-    /// The member list will be sorted alphabetically.
-    pub fn add_member(&mut self, member: WorkspaceMember) -> Result<()> {
-        let Some(workspace) = self.manifest.workspace.as_mut() else {
-            bail!(
-                "There is no workspace project at {}",
-                self.cargo_toml_path.display()
-            );
-        };
-
-        let Some(members) = workspace.members.as_mut() else {
-            bail!("There are no workspace members yet defined.");
-        };
-
-        if members.contains(&member.name) {
-            warn!(
-                "Project `{}` is already a member of the workspace",
-                member.name
-            );
-            return Ok(());
-        }
-
-        members.push(member.name.clone());
-        members.sort();
-
-        Ok(())
-    }
-
-    /// Save the updated manifest to disk.
-    pub fn save(&self) -> Result<()> {
-        let new_manifest = toml::to_string_pretty(&self.manifest)?;
-        let cargo_toml_path = &self.cargo_toml_path;
-        fs::write(cargo_toml_path, new_manifest)
-            .with_context(|| format!("Failed to write {}", cargo_toml_path.display()))?;
-
-        Ok(())
-    }
-}
-
-struct WorkspaceMember {
-    name: String,
-}
-
-impl WorkspaceMember {
-    pub fn try_new(member_path: &Path) -> Result<Self> {
-        let cargo_toml_path = member_path.join("Cargo.toml");
-        let content = fs::read_to_string(&cargo_toml_path)
-            .with_context(|| format!("Failed to read {}", cargo_toml_path.display()))?;
-        let manifest: TomlManifest = toml::from_str(&content)
-            .with_context(|| format!("Failed to parse {}", cargo_toml_path.display()))?;
-
-        let pkg = manifest.package().ok_or_else(|| {
-            anyhow!(
-                "No [package] section found in Cargo.toml at {}",
-                cargo_toml_path.display()
+    /// Path from the workspace root to `member_path`, joined with `/` so the
+    /// value written into `Cargo.toml` matches cargo's convention on every
+    /// platform (see `get_display_path` in `rust-lang/cargo`).
+    fn relative_path_for(&self, member_path: &Path) -> Result<String> {
+        let rel = member_path.strip_prefix(&self.root_dir).with_context(|| {
+            format!(
+                "Project path {} is not inside workspace root {}",
+                member_path.display(),
+                self.root_dir.display()
             )
         })?;
+        Ok(rel
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join("/"))
+    }
 
-        let name = pkg
-            .name
+    fn is_excluded(&self, relative_member_path: &str) -> bool {
+        self.manifest
+            .workspace
             .as_ref()
-            .ok_or_else(|| {
-                anyhow!(
-                    "No `package.name` found in Cargo.toml at {}",
-                    cargo_toml_path.display()
-                )
-            })?
-            .to_string();
+            .and_then(|ws| ws.exclude.as_ref())
+            .is_some_and(|exclude| exclude.iter().any(|e| e == relative_member_path))
+    }
 
-        Ok(Self { name })
+    fn is_covered_by_existing_member(&self, relative_member_path: &str) -> bool {
+        let Some(members) = self
+            .manifest
+            .workspace
+            .as_ref()
+            .and_then(|ws| ws.members.as_ref())
+        else {
+            return false;
+        };
+        members.iter().any(|entry| {
+            if entry == relative_member_path {
+                return true;
+            }
+            Pattern::new(entry)
+                .map(|p| p.matches(relative_member_path))
+                .unwrap_or(false)
+        })
+    }
+
+    fn append_member(&mut self, relative_member_path: String) -> Result<()> {
+        let workspace = self.manifest.workspace.as_mut().ok_or_else(|| {
+            anyhow!(
+                "There is no workspace project at {}",
+                self.cargo_toml_path.display()
+            )
+        })?;
+        let members = workspace.members.get_or_insert_with(Vec::new);
+        let was_sorted = members.windows(2).all(|w| w[0] <= w[1]);
+        members.push(relative_member_path);
+        if was_sorted {
+            members.sort();
+        }
+        Ok(())
+    }
+
+    fn save(&self) -> Result<()> {
+        let new_manifest = toml::to_string_pretty(&self.manifest)?;
+        fs::write(&self.cargo_toml_path, new_manifest)
+            .with_context(|| format!("Failed to write {}", self.cargo_toml_path.display()))?;
+        Ok(())
     }
 }

--- a/tests/integration/workspace_member.rs
+++ b/tests/integration/workspace_member.rs
@@ -1,6 +1,105 @@
 use crate::helpers::prelude::*;
 
 #[test]
+fn it_should_not_rewrite_manifest_when_new_member_is_already_covered_by_glob() {
+    // A `crates/*` glob already implicitly covers a new `crates/a` crate, so
+    // cargo-generate should leave the workspace manifest untouched — matching
+    // `cargo new`'s behavior. See `update_manifest_with_new_member` in cargo.
+    let workspace_project = tempdir()
+        .file(
+            "Cargo.toml",
+            indoc! {r#"
+                [workspace]
+                members = ["crates/*"]
+            "#},
+        )
+        // ensure `crates/` exists so we can `cd` into it below
+        .file("crates/.gitkeep", "")
+        .init_git()
+        .build();
+
+    let template = tempdir()
+        .file(
+            "Cargo.toml",
+            indoc! {r#"
+                [package]
+                name = "{{project-name}}"
+                version = "0.1.0"
+            "#},
+        )
+        .init_git()
+        .build();
+
+    binary()
+        .arg_name("a")
+        .arg_path(template.path())
+        .current_dir(workspace_project.path().join("crates"))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(workspace_project.exists("crates/a/Cargo.toml"));
+
+    // manifest should be unchanged (still just the glob, no `crates/a` literal).
+    let workspace_toml = workspace_project.read("Cargo.toml");
+    assert!(workspace_toml.contains(r#"members = ["crates/*"]"#));
+    assert!(!workspace_toml.contains(r#""crates/a""#));
+}
+
+#[test]
+fn it_should_skip_workspace_when_target_matches_workspace_exclude() {
+    let workspace_project = tempdir()
+        .file(
+            "Cargo.toml",
+            indoc! {r#"
+                [workspace]
+                members = ["crates/c1"]
+                exclude = ["crates/a"]
+            "#},
+        )
+        .file(
+            "crates/c1/Cargo.toml",
+            indoc! {r#"
+                [package]
+                name = "c1"
+                version = "0.1.0"
+            "#},
+        )
+        .init_git()
+        .build();
+
+    let template = tempdir()
+        .file(
+            "Cargo.toml",
+            indoc! {r#"
+                [package]
+                name = "{{project-name}}"
+                version = "0.1.0"
+            "#},
+        )
+        .init_git()
+        .build();
+
+    binary()
+        .arg_name("a")
+        .arg_path(template.path())
+        .current_dir(workspace_project.path().join("crates"))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    // the new project was created…
+    assert!(workspace_project.exists("crates/a/Cargo.toml"));
+
+    // …but the workspace manifest was left untouched because the target
+    // path is listed in `workspace.exclude`.
+    let workspace_toml = workspace_project.read("Cargo.toml");
+    assert!(workspace_toml.contains(r#"members = ["crates/c1"]"#));
+    assert!(workspace_toml.contains(r#"exclude = ["crates/a"]"#));
+    assert!(!workspace_toml.contains(r#""crates/a","#));
+}
+
+#[test]
 fn it_should_add_a_new_project_to_the_workspace_members() {
     let workspace_project = tempdir()
         .file(
@@ -47,6 +146,71 @@ fn it_should_add_a_new_project_to_the_workspace_members() {
         .contains(indoc! {r#"members = [
             "a",
             "c",
+        ]"#}));
+}
+
+/// Regression test for https://github.com/cargo-generate/cargo-generate/issues/1648:
+/// when generating from a nested directory (e.g. `crates/`) inside a workspace,
+/// the newly generated crate should still be added to the workspace's members list
+/// at the workspace root — mirroring what `cargo new` does by walking up the
+/// directory tree until a workspace manifest is found. The member entry must be
+/// the path relative to the workspace root, joined with forward slashes.
+#[test]
+fn it_should_add_a_new_project_from_a_nested_directory_to_the_workspace_members() {
+    let workspace_project = tempdir()
+        .file(
+            "Cargo.toml",
+            indoc! {r#"
+                [workspace]
+                members = ["crates/c1"]
+            "#},
+        )
+        .file(
+            "crates/c1/Cargo.toml",
+            indoc! {r#"
+                [package]
+                name = "c1"
+                version = "0.1.0"
+            "#},
+        )
+        .init_git()
+        .build();
+
+    let template = tempdir()
+        .file(
+            "Cargo.toml",
+            indoc! {r#"
+                [package]
+                name = "{{project-name}}"
+                version = "0.1.0"
+            "#},
+        )
+        .init_git()
+        .build();
+
+    binary()
+        .arg_name("a")
+        .arg_path(template.path())
+        .current_dir(workspace_project.path().join("crates"))
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Done!").from_utf8());
+
+    assert!(workspace_project.exists("crates/a/Cargo.toml"));
+    assert!(workspace_project
+        .read("crates/a/Cargo.toml")
+        .contains(r#"name = "a""#));
+
+    // the new project should **not** have an own git repository
+    assert!(!workspace_project.exists("crates/a/.git"));
+
+    // the workspace root Cargo.toml should have picked up the new nested member,
+    // relative to the workspace root, and remain sorted alphabetically
+    assert!(workspace_project
+        .read("Cargo.toml")
+        .contains(indoc! {r#"members = [
+            "crates/a",
+            "crates/c1",
         ]"#}));
 }
 


### PR DESCRIPTION
## Why

- Running cargo-generate from a nested folder (e.g. `crates/`) silently skipped the workspace `members` update — only the immediate parent was inspected. `cargo new` walks up until it finds a `[workspace]` manifest; we now do the same.
- The member entry was being written as the package name instead of the path relative to the workspace root, so even the flat case would break as soon as the crate lived under a subdir.
- Existing glob members (`crates/*`) and `workspace.exclude` were not respected, so we could either duplicate an entry a glob already covers or add an entry the user explicitly excluded.

## Impact

- Nested runs now correctly append `crates/foo` to the root workspace's `members` — matching what `cargo new` does.
- Path is written with forward slashes on every platform, matching cargo's `get_display_path`.
- Silent no-op when an existing glob already covers the new crate; warning + skip when the target matches `workspace.exclude`.

Closes #1648