### PR TITLE
chore: cover rename+delete on git-sourced template (see #1613)

### DIFF
--- a/tests/integration/hooks_and_rhai.rs
+++ b/tests/integration/hooks_and_rhai.rs
@@ -44,6 +44,62 @@ fn it_removes_hook_files_from_output_without_touching_cwd() {
     assert!(dir.read("post-script.rhai").contains("decoy"));
 }
 
+// Regression test for https://github.com/cargo-generate/cargo-generate/issues/1613:
+// a pre-script.rhai that renames the selected license file and deletes the
+// rest must succeed when the template is pulled from a git source. The
+// original report saw "OS Error 53 (Network Path was not found)" on Windows
+// in this exact shape (mirrors
+// https://github.com/Reloaded-Project/reloaded-templates-rust/blob/main/templates/general/pre-script.rhai).
+#[test]
+fn it_renames_and_deletes_files_from_git_source() {
+    let template = tempdir()
+        .file(
+            "pre-script.rhai",
+            indoc! {r#"
+            let license = variable::get("license").to_lower();
+            if license == "mit" {
+                file::rename("LICENSE-MIT", "LICENSE");
+                file::delete("LICENSE-APACHE");
+            } else {
+                file::rename("LICENSE-APACHE", "LICENSE");
+                file::delete("LICENSE-MIT");
+            }
+        "#},
+        )
+        .file("LICENSE-MIT", "MIT License text")
+        .file("LICENSE-APACHE", "Apache License text")
+        .file(
+            "cargo-generate.toml",
+            indoc! {r#"
+            [placeholders.license]
+            type = "string"
+            prompt = "license"
+            default = "mit"
+
+            [hooks]
+            pre = ["pre-script.rhai"]
+            "#},
+        )
+        .init_git()
+        .build();
+
+    let dir = tempdir().build();
+
+    binary()
+        .arg_git(template.path())
+        .arg_name("script-project")
+        .arg("-d")
+        .arg("license=mit")
+        .current_dir(dir.path())
+        .assert()
+        .success();
+
+    assert!(dir.exists("script-project/LICENSE"));
+    assert!(!dir.exists("script-project/LICENSE-MIT"));
+    assert!(!dir.exists("script-project/LICENSE-APACHE"));
+    assert!(dir.read("script-project/LICENSE").contains("MIT"));
+}
+
 #[test]
 fn it_runs_all_hook_types() {
     let template = tempdir()


### PR DESCRIPTION
## Why

https://github.com/cargo-generate/cargo-generate/issues/1613 reports `OS Error 53 (Network Path was not found)` on Windows when a `pre-script.rhai` renames the selected license file and deletes the rest against a git-sourced template. https://github.com/cargo-generate/cargo-generate/pull/1672 (merged) retired process-wide CWD mutation in hook execution, which is a plausible root cause for that error — but no one has confirmed the fix on Windows.

This PR adds a regression test that reproduces the reporter's exact shape (mirrors https://github.com/Reloaded-Project/reloaded-templates-rust/blob/main/templates/general/pre-script.rhai). If the Windows CI leg stays green, we can close https://github.com/cargo-generate/cargo-generate/issues/1613.

## What

- New integration test `it_renames_and_deletes_files_from_git_source` in `tests/integration/hooks_and_rhai.rs`.
- Not `cfg`-gated — runs on all platforms; Windows is the one that matters.

## Test plan

- [x] Passes locally on macOS (`cargo test --test integration hooks_and_rhai::it_renames_and_deletes_files_from_git_source`)
- [x] Passes on Windows CI — the point of this PR